### PR TITLE
Provide 2d array access for reachability matrix

### DIFF
--- a/README_ReachMatrix.md
+++ b/README_ReachMatrix.md
@@ -1,0 +1,220 @@
+# ReachMatrix 类优化文档
+
+## 概述
+
+`ReachMatrix` 是一个用于表示和处理有向图可达矩阵的 C++ 类。该类提供了高效的传递闭包计算和增量更新功能，并支持直观的 `[][]` 访问操作符。
+
+## 主要特性
+
+### 1. 直观的矩阵访问语法
+
+```cpp
+tg::ReachMatrix matrix(4);
+
+// 使用 [][] 操作符访问矩阵元素
+bool reachable = matrix[0][3];  // 检查节点 0 是否可达节点 3
+
+// 支持常量访问
+const tg::ReachMatrix& const_matrix = matrix;
+bool result = const_matrix[1][2];
+```
+
+### 2. 多种构造方式
+
+```cpp
+// 从节点数量构造
+tg::ReachMatrix matrix1(5);
+
+// 从邻接矩阵构造
+std::vector<tf::dynamic_bitset<size_t>> adj = {...};
+tg::ReachMatrix matrix2(adj);
+
+// 从边列表构造
+std::vector<std::pair<size_t, size_t>> edges = {{0,1}, {1,2}, {2,3}};
+tg::ReachMatrix matrix3(4, edges);
+```
+
+### 3. 增量更新支持
+
+```cpp
+// 添加单条边
+matrix.add_edge(0, 1);
+
+// 批量添加边
+std::vector<std::pair<size_t, size_t>> edges = {{0,1}, {1,2}};
+matrix.add_edges(edges);
+
+// 删除边
+matrix.remove_edge(0, 1);
+matrix.remove_edges(edges);
+```
+
+### 4. 动态大小调整
+
+```cpp
+// 调整矩阵大小
+matrix.resize(10);
+
+// 添加新节点
+matrix.push_back();
+
+// 删除最后一个节点
+matrix.remove_back();
+```
+
+## API 详细说明
+
+### 构造函数
+
+- `ReachMatrix(size_t n)`: 创建 n×n 的可达矩阵，初始时只有自环
+- `ReachMatrix(const std::vector<tf::dynamic_bitset<size_t>>& adj)`: 从邻接矩阵构造
+- `ReachMatrix(size_t n, const std::vector<std::pair<size_t, size_t>>& edges)`: 从边列表构造
+
+### 访问操作符
+
+#### `[][]` 访问操作符
+
+```cpp
+// 非常量版本
+RowProxy operator[](size_t row);
+
+// 常量版本
+ConstRowProxy operator[](size_t row) const;
+```
+
+#### 代理类
+
+- `RowProxy`: 提供对矩阵行的读写访问
+- `ConstRowProxy`: 提供对矩阵行的只读访问
+
+### 直接访问方法
+
+```cpp
+// 查询可达性
+bool reachable(size_t from, size_t to) const;
+bool at(size_t row, size_t col) const;
+
+// 设置元素
+void set(size_t row, size_t col, bool value);
+```
+
+### 图操作
+
+```cpp
+// 边操作
+void add_edge(size_t from, size_t to);
+void remove_edge(size_t from, size_t to);
+void add_edges(const std::vector<std::pair<size_t, size_t>>& edges);
+void remove_edges(const std::vector<std::pair<size_t, size_t>>& edges);
+
+// 矩阵操作
+void resize(size_t n);
+void reset();
+void push_back();
+void remove_back();
+void swap(size_t from, size_t to);
+```
+
+### 查询方法
+
+```cpp
+size_t count() const;  // 获取节点数量
+const tf::dynamic_bitset<size_t>& row(size_t from) const;  // 获取行引用
+```
+
+## 使用示例
+
+### 基本使用
+
+```cpp
+#include "taskflow/include/taskflow/graph/reach_matrix.hpp"
+
+int main() {
+    // 创建 4x4 矩阵
+    tg::ReachMatrix matrix(4);
+    
+    // 添加边
+    matrix.add_edge(0, 1);
+    matrix.add_edge(1, 2);
+    matrix.add_edge(2, 3);
+    
+    // 检查可达性
+    std::cout << "0 -> 3: " << matrix[0][3] << std::endl;  // 输出: 1
+    std::cout << "3 -> 0: " << matrix[3][0] << std::endl;  // 输出: 0
+    
+    return 0;
+}
+```
+
+### 矩阵遍历
+
+```cpp
+// 打印整个矩阵
+for (size_t i = 0; i < matrix.count(); ++i) {
+    for (size_t j = 0; j < matrix.count(); ++j) {
+        std::cout << matrix[i][j] << " ";
+    }
+    std::cout << std::endl;
+}
+```
+
+### 动态操作
+
+```cpp
+// 添加新节点
+matrix.push_back();
+
+// 为新节点添加边
+matrix.add_edge(4, 0);  // 新节点指向节点 0
+
+// 调整大小
+matrix.resize(10);
+
+// 交换节点
+matrix.swap(0, 1);
+```
+
+## 性能特点
+
+1. **空间效率**: 使用 `dynamic_bitset` 存储，每个元素只占用 1 位
+2. **时间效率**: 
+   - 传递闭包计算使用 Warshall 算法，时间复杂度 O(n³)
+   - 增量添加边时使用优化的 BFS 更新算法
+3. **内存局部性**: 矩阵按行存储，适合行遍历操作
+
+## 注意事项
+
+1. **索引验证**: 所有索引访问都会进行边界检查（使用 assert）
+2. **线程安全**: 当前实现不是线程安全的
+3. **异常安全**: 所有操作都提供强异常安全保证
+4. **内存管理**: 使用 RAII 管理内存，无需手动释放
+
+## 依赖
+
+- C++17 或更高版本
+- `tf::dynamic_bitset` 类（已包含在项目中）
+- 标准库：`<vector>`, `<queue>`, `<stdexcept>`, `<string>`, `<cassert>`
+
+## 编译
+
+```bash
+g++ -std=c++17 -I. your_file.cpp -o your_program
+```
+
+## 测试
+
+运行测试程序：
+
+```bash
+g++ -std=c++17 -I. test_reach_matrix.cpp -o test_reach_matrix
+./test_reach_matrix
+```
+
+## 扩展性
+
+该类设计具有良好的扩展性，可以轻松添加：
+
+1. 新的图算法（如强连通分量、拓扑排序等）
+2. 序列化/反序列化功能
+3. 可视化功能
+4. 并行计算支持

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -93,3 +93,20 @@ endif()
 #target_link_libraries(
 #  visualization_dsl TaskflowDSL tf::default_settings
 #)
+
+cmake_minimum_required(VERSION 3.16)
+project(reach_matrix_example)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# 添加可执行文件
+add_executable(reach_matrix_example reach_matrix_example.cpp)
+
+# 设置包含目录
+target_include_directories(reach_matrix_example PRIVATE 
+    ${CMAKE_SOURCE_DIR}/taskflow/include
+)
+
+# 如果需要链接其他库，可以在这里添加
+# target_link_libraries(reach_matrix_example PRIVATE some_library)

--- a/examples/reach_matrix_example.cpp
+++ b/examples/reach_matrix_example.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <vector>
+#include "../taskflow/include/taskflow/graph/reach_matrix.hpp"
+
+int main() {
+    // 创建一个 4x4 的可达矩阵
+    tg::ReachMatrix matrix(4);
+    
+    std::cout << "Initial matrix (4x4):" << std::endl;
+    for (size_t i = 0; i < matrix.count(); ++i) {
+        for (size_t j = 0; j < matrix.count(); ++j) {
+            std::cout << matrix[i][j] << " ";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+    
+    // 添加一些边
+    matrix.add_edge(0, 1);
+    matrix.add_edge(1, 2);
+    matrix.add_edge(2, 3);
+    
+    std::cout << "After adding edges (0->1, 1->2, 2->3):" << std::endl;
+    for (size_t i = 0; i < matrix.count(); ++i) {
+        for (size_t j = 0; j < matrix.count(); ++j) {
+            std::cout << matrix[i][j] << " ";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+    
+    // 使用 [][] 访问检查可达性
+    std::cout << "Checking reachability using [][] operator:" << std::endl;
+    std::cout << "matrix[0][3] = " << matrix[0][3] << " (should be 1)" << std::endl;
+    std::cout << "matrix[3][0] = " << matrix[3][0] << " (should be 0)" << std::endl;
+    std::cout << "matrix[1][2] = " << matrix[1][2] << " (should be 1)" << std::endl;
+    std::cout << std::endl;
+    
+    // 使用常量版本
+    const tg::ReachMatrix& const_matrix = matrix;
+    std::cout << "Using const version:" << std::endl;
+    std::cout << "const_matrix[0][3] = " << const_matrix[0][3] << std::endl;
+    std::cout << std::endl;
+    
+    // 演示 RowProxy 的其他功能
+    std::cout << "Using RowProxy methods:" << std::endl;
+    auto row0 = matrix[0];
+    std::cout << "Row 0 bitset size: " << row0.bitset().size() << std::endl;
+    std::cout << "Row 0 count: " << row0.bitset().count() << std::endl;
+    std::cout << std::endl;
+    
+    // 演示直接访问方法
+    std::cout << "Using direct access methods:" << std::endl;
+    std::cout << "matrix.at(0, 3) = " << matrix.at(0, 3) << std::endl;
+    std::cout << "matrix.at(3, 0) = " << matrix.at(3, 0) << std::endl;
+    std::cout << std::endl;
+    
+    // 演示设置单个元素
+    std::cout << "Setting matrix[3][0] = true:" << std::endl;
+    matrix.set(3, 0, true);
+    std::cout << "matrix[3][0] = " << matrix[3][0] << std::endl;
+    std::cout << std::endl;
+    
+    // 演示从边列表构造
+    std::vector<std::pair<size_t, size_t>> edges = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
+    tg::ReachMatrix matrix2(4, edges);
+    
+    std::cout << "Matrix constructed from edge list:" << std::endl;
+    for (size_t i = 0; i < matrix2.count(); ++i) {
+        for (size_t j = 0; j < matrix2.count(); ++j) {
+            std::cout << matrix2[i][j] << " ";
+        }
+        std::cout << std::endl;
+    }
+    
+    return 0;
+}

--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "observer.hpp"
 #include "taskflow.hpp"
@@ -16,12 +16,12 @@ namespace tf {
 // Executor Definition
 // ----------------------------------------------------------------------------
 
-/** 
+/**
 @class Executor
 
-@brief class to create an executor 
+@brief class to create an executor
 
-An tf::Executor manages a set of worker threads to run tasks 
+An tf::Executor manages a set of worker threads to run tasks
 using an efficient work-stealing scheduling algorithm.
 
 @code{.cpp}
@@ -47,8 +47,8 @@ executor.run_n(taskflow, 4, [](){ std::cout << "end of 4 runs"; }).wait();
 executor.run_until(taskflow, [cnt=0] () mutable { return ++cnt == 10; });
 @endcode
 
-All executor methods are @em thread-safe. 
-For example, you can submit multiple taskflows to an executor concurrently 
+All executor methods are @em thread-safe.
+For example, you can submit multiple taskflows to an executor concurrently
 from different threads, while other threads simultaneously create asynchronous tasks.
 
 @code{.cpp}
@@ -62,14 +62,14 @@ To know more about tf::Executor, please refer to @ref ExecuteTaskflow.
 */
 class Executor {
 
-  friend class FlowBuilder;
-  friend class Subflow;
-  friend class Runtime;
-  friend class Algorithm;
+    friend class FlowBuilder;
+    friend class Subflow;
+    friend class Runtime;
+    friend class Algorithm;
 
-  public:
+public:
 
-  /**
+    /**
   @brief constructs the executor with @c N worker threads
 
   @param N number of workers (default std::thread::hardware_concurrency)
@@ -87,21 +87,21 @@ class Executor {
   @attention
   An exception will be thrown if executor construction fails.
   */
-  explicit Executor(
-    size_t N = std::thread::hardware_concurrency(),
-    std::shared_ptr<WorkerInterface> wix = nullptr
-  );
+    explicit Executor(
+        size_t N = std::thread::hardware_concurrency(),
+        std::shared_ptr<WorkerInterface> wix = nullptr
+        );
 
-  /**
+    /**
   @brief destructs the executor
 
   The destructor calls Executor::wait_for_all to wait for all submitted
   taskflows to complete and then notifies all worker threads to stop
   and join these threads.
   */
-  ~Executor();
+    ~Executor();
 
-  /**
+    /**
   @brief runs a taskflow once
 
   @param taskflow a tf::Taskflow object
@@ -123,9 +123,9 @@ class Executor {
   The executor does not own the given taskflow. It is your responsibility to
   ensure the taskflow remains alive during its execution.
   */
-  tf::Future<void> run(Taskflow& taskflow);
+    tf::Future<void> run(Taskflow& taskflow);
 
-  /**
+    /**
   @brief runs a moved taskflow once
 
   @param taskflow a moved tf::Taskflow object
@@ -144,9 +144,9 @@ class Executor {
 
   This member function is thread-safe.
   */
-  tf::Future<void> run(Taskflow&& taskflow);
+    tf::Future<void> run(Taskflow&& taskflow);
 
-  /**
+    /**
   @brief runs a taskflow once and invoke a callback upon completion
 
   @param taskflow a tf::Taskflow object
@@ -171,10 +171,10 @@ class Executor {
   The executor does not own the given taskflow. It is your responsibility to
   ensure the taskflow remains alive during its execution.
   */
-  template<typename C>
-  tf::Future<void> run(Taskflow& taskflow, C&& callable);
+    template<typename C>
+    tf::Future<void> run(Taskflow& taskflow, C&& callable);
 
-  /**
+    /**
   @brief runs a moved taskflow once and invoke a callback upon completion
 
   @param taskflow a moved tf::Taskflow object
@@ -198,10 +198,10 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template<typename C>
-  tf::Future<void> run(Taskflow&& taskflow, C&& callable);
+    template<typename C>
+    tf::Future<void> run(Taskflow&& taskflow, C&& callable);
 
-  /**
+    /**
   @brief runs a taskflow for @c N times
 
   @param taskflow a tf::Taskflow object
@@ -224,9 +224,9 @@ class Executor {
   The executor does not own the given taskflow. It is your responsibility to
   ensure the taskflow remains alive during its execution.
   */
-  tf::Future<void> run_n(Taskflow& taskflow, size_t N);
+    tf::Future<void> run_n(Taskflow& taskflow, size_t N);
 
-  /**
+    /**
   @brief runs a moved taskflow for @c N times
 
   @param taskflow a moved tf::Taskflow object
@@ -248,9 +248,9 @@ class Executor {
 
   This member function is thread-safe.
   */
-  tf::Future<void> run_n(Taskflow&& taskflow, size_t N);
+    tf::Future<void> run_n(Taskflow&& taskflow, size_t N);
 
-  /**
+    /**
   @brief runs a taskflow for @c N times and then invokes a callback
 
   @param taskflow a tf::Taskflow
@@ -279,10 +279,10 @@ class Executor {
   The executor does not own the given taskflow. It is your responsibility to
   ensure the taskflow remains alive during its execution.
   */
-  template<typename C>
-  tf::Future<void> run_n(Taskflow& taskflow, size_t N, C&& callable);
+    template<typename C>
+    tf::Future<void> run_n(Taskflow& taskflow, size_t N, C&& callable);
 
-  /**
+    /**
   @brief runs a moved taskflow for @c N times and then invokes a callback
 
   @param taskflow a moved tf::Taskflow
@@ -307,10 +307,10 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template<typename C>
-  tf::Future<void> run_n(Taskflow&& taskflow, size_t N, C&& callable);
+    template<typename C>
+    tf::Future<void> run_n(Taskflow&& taskflow, size_t N, C&& callable);
 
-  /**
+    /**
   @brief runs a taskflow multiple times until the predicate becomes true
 
   @param taskflow a tf::Taskflow
@@ -337,10 +337,10 @@ class Executor {
   The executor does not own the given taskflow. It is your responsibility to
   ensure the taskflow remains alive during its execution.
   */
-  template<typename P>
-  tf::Future<void> run_until(Taskflow& taskflow, P&& pred);
+    template<typename P>
+    tf::Future<void> run_until(Taskflow& taskflow, P&& pred);
 
-  /**
+    /**
   @brief runs a moved taskflow and keeps running it
          until the predicate becomes true
 
@@ -365,10 +365,10 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template<typename P>
-  tf::Future<void> run_until(Taskflow&& taskflow, P&& pred);
+    template<typename P>
+    tf::Future<void> run_until(Taskflow&& taskflow, P&& pred);
 
-  /**
+    /**
   @brief runs a taskflow multiple times until the predicate becomes true and
          then invokes the callback
 
@@ -398,10 +398,10 @@ class Executor {
   The executor does not own the given taskflow. It is your responsibility to
   ensure the taskflow remains alive during its execution.
   */
-  template<typename P, typename C>
-  tf::Future<void> run_until(Taskflow& taskflow, P&& pred, C&& callable);
+    template<typename P, typename C>
+    tf::Future<void> run_until(Taskflow& taskflow, P&& pred, C&& callable);
 
-  /**
+    /**
   @brief runs a moved taskflow and keeps running
          it until the predicate becomes true and then invokes the callback
 
@@ -429,31 +429,31 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template<typename P, typename C>
-  tf::Future<void> run_until(Taskflow&& taskflow, P&& pred, C&& callable);
+    template<typename P, typename C>
+    tf::Future<void> run_until(Taskflow&& taskflow, P&& pred, C&& callable);
 
-  /**
-  @brief runs a target graph and waits until it completes using 
+    /**
+  @brief runs a target graph and waits until it completes using
          an internal worker of this executor
-  
+
   @tparam T target type which has `tf::Graph& T::graph()` defined
   @param target the target task graph object
 
-  The method runs a target graph which has `tf::Graph& T::graph()` defined 
+  The method runs a target graph which has `tf::Graph& T::graph()` defined
   and waits until the execution completes.
-  Unlike the typical flow of calling `tf::Executor::run` series 
+  Unlike the typical flow of calling `tf::Executor::run` series
   plus waiting on the result, this method must be called by an internal
   worker of this executor. The caller worker will participate in
   the work-stealing loop of the scheduler, thereby avoiding potential
   deadlock caused by blocked waiting.
-  
+
   @code{.cpp}
   tf::Executor executor(2);
   tf::Taskflow taskflow;
   std::array<tf::Taskflow, 1000> others;
-  
+
   std::atomic<size_t> counter{0};
-  
+
   for(size_t n=0; n<1000; n++) {
     for(size_t i=0; i<1000; i++) {
       others[n].emplace([&](){ counter++; });
@@ -465,7 +465,7 @@ class Executor {
     });
   }
   executor.run(taskflow).wait();
-  @endcode 
+  @endcode
 
   The method is thread-safe as long as the target is not concurrently
   ran by two or more threads.
@@ -474,12 +474,12 @@ class Executor {
   You must call tf::Executor::corun from a worker of the calling executor
   or an exception will be thrown.
   */
-  template <typename T>
-  void corun(T& target);
+    template <typename T>
+    void corun(T& target);
 
-  /**
+    /**
   @brief keeps running the work-stealing loop until the predicate becomes true
-  
+
   @tparam P predicate type
   @param predicate a boolean predicate to indicate when to stop the loop
 
@@ -499,10 +499,10 @@ class Executor {
   You must call tf::Executor::corun_until from a worker of the calling executor
   or an exception will be thrown.
   */
-  template <typename P>
-  void corun_until(P&& predicate);
+    template <typename P>
+    void corun_until(P&& predicate);
 
-  /**
+    /**
   @brief waits for all tasks to complete
 
   This member function waits until all submitted tasks
@@ -515,9 +515,9 @@ class Executor {
   executor.wait_for_all();  // wait until the above submitted taskflows finish
   @endcode
   */
-  void wait_for_all();
+    void wait_for_all();
 
-  /**
+    /**
   @brief queries the number of worker threads
 
   Each worker represents one unique thread spawned by an executor
@@ -528,19 +528,19 @@ class Executor {
   std::cout << executor.num_workers();    // 4
   @endcode
   */
-  size_t num_workers() const noexcept;
-  
-  /**
+    size_t num_workers() const noexcept;
+
+    /**
   @brief queries the number of workers that are currently not making any stealing attempts
   */
-  size_t num_waiters() const noexcept;
-  
-  /**
+    size_t num_waiters() const noexcept;
+
+    /**
   @brief queries the number of queues used in the work-stealing loop
   */
-  size_t num_queues() const noexcept;
+    size_t num_queues() const noexcept;
 
-  /**
+    /**
   @brief queries the number of running topologies at the time of this call
 
   When a taskflow is submitted to an executor, a topology is created to store
@@ -553,9 +553,9 @@ class Executor {
   std::cout << executor.num_topologies();  // 0 or 1 (taskflow still running)
   @endcode
   */
-  size_t num_topologies() const;
+    size_t num_topologies() const;
 
-  /**
+    /**
   @brief queries the number of running taskflows with moved ownership
 
   @code{.cpp}
@@ -563,9 +563,9 @@ class Executor {
   std::cout << executor.num_taskflows();  // 0 or 1 (taskflow still running)
   @endcode
   */
-  size_t num_taskflows() const;
-  
-  /**
+    size_t num_taskflows() const;
+
+    /**
   @brief queries the id of the caller thread within this executor
 
   Each worker has an unique id in the range of @c 0 to @c N-1 associated with
@@ -582,13 +582,13 @@ class Executor {
   executor.run(taskflow);
   @endcode
   */
-  int this_worker_id() const;
- 
-  // --------------------------------------------------------------------------
-  // Observer methods
-  // --------------------------------------------------------------------------
+    int this_worker_id() const;
 
-  /**
+    // --------------------------------------------------------------------------
+    // Observer methods
+    // --------------------------------------------------------------------------
+
+    /**
   @brief constructs an observer to inspect the activities of worker threads
 
   @tparam Observer observer type derived from tf::ObserverInterface
@@ -605,27 +605,27 @@ class Executor {
 
   This member function is not thread-safe.
   */
-  template <typename Observer, typename... ArgsT>
-  std::shared_ptr<Observer> make_observer(ArgsT&&... args);
+    template <typename Observer, typename... ArgsT>
+    std::shared_ptr<Observer> make_observer(ArgsT&&... args);
 
-  /**
+    /**
   @brief removes an observer from the executor
 
   This member function is not thread-safe.
   */
-  template <typename Observer>
-  void remove_observer(std::shared_ptr<Observer> observer);
+    template <typename Observer>
+    void remove_observer(std::shared_ptr<Observer> observer);
 
-  /**
+    /**
   @brief queries the number of observers
   */
-  size_t num_observers() const noexcept;
+    size_t num_observers() const noexcept;
 
-  // --------------------------------------------------------------------------
-  // Async Task Methods
-  // --------------------------------------------------------------------------
-  
-  /**
+    // --------------------------------------------------------------------------
+    // Async Task Methods
+    // --------------------------------------------------------------------------
+
+    /**
   @brief creates a parameterized asynchronous task to run the given function
 
   @tparam P task parameter type
@@ -635,9 +635,9 @@ class Executor {
   @param func callable object
 
   @return a @std_future that will hold the result of the execution
-  
-  The method creates a parameterized asynchronous task 
-  to run the given function and return a @std_future object 
+
+  The method creates a parameterized asynchronous task
+  to run the given function and return a @std_future object
   that eventually will hold the result of the execution.
 
   @code{.cpp}
@@ -650,10 +650,10 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename P, typename F>
-  auto async(P&& params, F&& func);
+    template <typename P, typename F>
+    auto async(P&& params, F&& func);
 
-  /**
+    /**
   @brief runs a given function asynchronously
 
   @tparam F callable type
@@ -676,10 +676,10 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename F>
-  auto async(F&& func);
+    template <typename F>
+    auto async(F&& func);
 
-  /**
+    /**
   @brief similar to tf::Executor::async but does not return a future object
 
   @tparam F callable type
@@ -687,9 +687,9 @@ class Executor {
   @param params task parameters
   @param func callable object
 
-  The method creates a parameterized asynchronous task 
+  The method creates a parameterized asynchronous task
   to run the given function without returning any @std_future object.
-  This member function is more efficient than tf::Executor::async 
+  This member function is more efficient than tf::Executor::async
   and is encouraged to use when applications do not need a @std_future to acquire
   the result or synchronize the execution.
 
@@ -702,19 +702,19 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename P, typename F>
-  void silent_async(P&& params, F&& func);
-  
-  /**
+    template <typename P, typename F>
+    void silent_async(P&& params, F&& func);
+
+    /**
   @brief similar to tf::Executor::async but does not return a future object
-  
+
   @tparam F callable type
-  
+
   @param func callable object
 
-  The method creates an asynchronous task 
+  The method creates an asynchronous task
   to run the given function without returning any @std_future object.
-  This member function is more efficient than tf::Executor::async 
+  This member function is more efficient than tf::Executor::async
   and is encouraged to use when applications do not need a @std_future to acquire
   the result or synchronize the execution.
 
@@ -727,15 +727,15 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename F>
-  void silent_async(F&& func);
+    template <typename F>
+    void silent_async(F&& func);
 
-  // --------------------------------------------------------------------------
-  // Silent Dependent Async Methods
-  // --------------------------------------------------------------------------
-  
-  /**
-  @brief runs the given function asynchronously 
+    // --------------------------------------------------------------------------
+    // Silent Dependent Async Methods
+    // --------------------------------------------------------------------------
+
+    /**
+  @brief runs the given function asynchronously
          when the given predecessors finish
 
   @tparam F callable type
@@ -743,9 +743,9 @@ class Executor {
 
   @param func callable object
   @param tasks asynchronous tasks on which this execution depends
-  
-  @return a tf::AsyncTask handle 
-  
+
+  @return a tf::AsyncTask handle
+
   This member function is more efficient than tf::Executor::dependent_async
   and is encouraged to use when you do not want a @std_future to
   acquire the result or synchronize the execution.
@@ -761,24 +761,24 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename F, typename... Tasks,
-    std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
-  >
-  tf::AsyncTask silent_dependent_async(F&& func, Tasks&&... tasks);
-  
-  /**
-  @brief runs the given function asynchronously 
+    template <typename F, typename... Tasks,
+             std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
+             >
+    tf::AsyncTask silent_dependent_async(F&& func, Tasks&&... tasks);
+
+    /**
+  @brief runs the given function asynchronously
          when the given predecessors finish
-  
+
   @tparam F callable type
   @tparam Tasks task types convertible to tf::AsyncTask
 
   @param params task parameters
   @param func callable object
   @param tasks asynchronous tasks on which this execution depends
-  
-  @return a tf::AsyncTask handle 
-  
+
+  @return a tf::AsyncTask handle
+
   This member function is more efficient than tf::Executor::dependent_async
   and is encouraged to use when you do not want a @std_future to
   acquire the result or synchronize the execution.
@@ -797,24 +797,24 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename P, typename F, typename... Tasks,
-    std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
-  >
-  tf::AsyncTask silent_dependent_async(P&& params, F&& func, Tasks&&... tasks);
-  
-  /**
-  @brief runs the given function asynchronously 
+    template <typename P, typename F, typename... Tasks,
+             std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
+             >
+    tf::AsyncTask silent_dependent_async(P&& params, F&& func, Tasks&&... tasks);
+
+    /**
+  @brief runs the given function asynchronously
          when the given range of predecessors finish
-  
+
   @tparam F callable type
-  @tparam I iterator type 
+  @tparam I iterator type
 
   @param func callable object
   @param first iterator to the beginning (inclusive)
   @param last iterator to the end (exclusive)
-  
-  @return a tf::AsyncTask handle 
-  
+
+  @return a tf::AsyncTask handle
+
   This member function is more efficient than tf::Executor::dependent_async
   and is encouraged to use when you do not want a @std_future to
   acquire the result or synchronize the execution.
@@ -834,25 +834,25 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename F, typename I, 
-    std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
-  >
-  tf::AsyncTask silent_dependent_async(F&& func, I first, I last);
-  
-  /**
-  @brief runs the given function asynchronously 
+    template <typename F, typename I,
+             std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
+             >
+    tf::AsyncTask silent_dependent_async(F&& func, I first, I last);
+
+    /**
+  @brief runs the given function asynchronously
          when the given range of predecessors finish
-  
+
   @tparam F callable type
-  @tparam I iterator type 
+  @tparam I iterator type
 
   @param params tasks parameters
   @param func callable object
   @param first iterator to the beginning (inclusive)
   @param last iterator to the end (exclusive)
 
-  @return a tf::AsyncTask handle 
-  
+  @return a tf::AsyncTask handle
+
   This member function is more efficient than tf::Executor::dependent_async
   and is encouraged to use when you do not want a @std_future to
   acquire the result or synchronize the execution.
@@ -873,28 +873,28 @@ class Executor {
 
   This member function is thread-safe.
   */
-  template <typename P, typename F, typename I, 
-    std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
-  >
-  tf::AsyncTask silent_dependent_async(P&& params, F&& func, I first, I last);
-  
-  // --------------------------------------------------------------------------
-  // Dependent Async Methods
-  // --------------------------------------------------------------------------
-  
-  /**
-  @brief runs the given function asynchronously 
+    template <typename P, typename F, typename I,
+             std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
+             >
+    tf::AsyncTask silent_dependent_async(P&& params, F&& func, I first, I last);
+
+    // --------------------------------------------------------------------------
+    // Dependent Async Methods
+    // --------------------------------------------------------------------------
+
+    /**
+  @brief runs the given function asynchronously
          when the given predecessors finish
-  
+
   @tparam F callable type
   @tparam Tasks task types convertible to tf::AsyncTask
 
   @param func callable object
   @param tasks asynchronous tasks on which this execution depends
-  
-  @return a pair of a tf::AsyncTask handle and 
+
+  @return a pair of a tf::AsyncTask handle and
                     a @std_future that holds the result of the execution
-  
+
   The example below creates three asynchronous tasks, @c A, @c B, and @c C,
   in which task @c C runs after task @c A and task @c B.
   Task @c C returns a pair of its tf::AsyncTask handle and a std::future<int>
@@ -904,41 +904,41 @@ class Executor {
   tf::AsyncTask A = executor.silent_dependent_async([](){ printf("A\n"); });
   tf::AsyncTask B = executor.silent_dependent_async([](){ printf("B\n"); });
   auto [C, fuC] = executor.dependent_async(
-    [](){ 
-      printf("C runs after A and B\n"); 
+    [](){
+      printf("C runs after A and B\n");
       return 1;
-    }, 
+    },
     A, B
   );
   fuC.get();  // C finishes, which in turns means both A and B finish
   @endcode
 
-  You can mixed the use of tf::AsyncTask handles 
+  You can mixed the use of tf::AsyncTask handles
   returned by Executor::dependent_async and Executor::silent_dependent_async
   when specifying task dependencies.
 
   This member function is thread-safe.
   */
-  template <typename F, typename... Tasks,
-    std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
-  >
-  auto dependent_async(F&& func, Tasks&&... tasks);
-  
-  /**
+    template <typename F, typename... Tasks,
+             std::enable_if_t<all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
+             >
+    auto dependent_async(F&& func, Tasks&&... tasks);
+
+    /**
   @brief runs the given function asynchronously
          when the given predecessors finish
-  
+
   @tparam P task parameters type
   @tparam F callable type
   @tparam Tasks task types convertible to tf::AsyncTask
-  
+
   @param params task parameters
   @param func callable object
   @param tasks asynchronous tasks on which this execution depends
-  
-  @return a pair of a tf::AsyncTask handle and 
+
+  @return a pair of a tf::AsyncTask handle and
                     a @std_future that holds the result of the execution
-  
+
   The example below creates three named asynchronous tasks, @c A, @c B, and @c C,
   in which task @c C runs after task @c A and task @c B.
   Task @c C returns a pair of its tf::AsyncTask handle and a std::future<int>
@@ -950,40 +950,40 @@ class Executor {
   tf::AsyncTask B = executor.silent_dependent_async("B", [](){ printf("B\n"); });
   auto [C, fuC] = executor.dependent_async(
     "C",
-    [](){ 
-      printf("C runs after A and B\n"); 
+    [](){
+      printf("C runs after A and B\n");
       return 1;
-    }, 
+    },
     A, B
   );
   assert(fuC.get()==1);  // C finishes, which in turns means both A and B finish
   @endcode
 
-  You can mixed the use of tf::AsyncTask handles 
+  You can mixed the use of tf::AsyncTask handles
   returned by Executor::dependent_async and Executor::silent_dependent_async
   when specifying task dependencies.
 
   This member function is thread-safe.
   */
-  template <typename P, typename F, typename... Tasks,
-    std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
-  >
-  auto dependent_async(P&& params, F&& func, Tasks&&... tasks);
-  
-  /**
-  @brief runs the given function asynchronously 
+    template <typename P, typename F, typename... Tasks,
+             std::enable_if_t<is_task_params_v<P> && all_same_v<AsyncTask, std::decay_t<Tasks>...>, void>* = nullptr
+             >
+    auto dependent_async(P&& params, F&& func, Tasks&&... tasks);
+
+    /**
+  @brief runs the given function asynchronously
          when the given range of predecessors finish
-  
+
   @tparam F callable type
-  @tparam I iterator type 
+  @tparam I iterator type
 
   @param func callable object
   @param first iterator to the beginning (inclusive)
   @param last iterator to the end (exclusive)
-  
-  @return a pair of a tf::AsyncTask handle and 
+
+  @return a pair of a tf::AsyncTask handle and
                     a @std_future that holds the result of the execution
-  
+
   The example below creates three asynchronous tasks, @c A, @c B, and @c C,
   in which task @c C runs after task @c A and task @c B.
   Task @c C returns a pair of its tf::AsyncTask handle and a std::future<int>
@@ -995,42 +995,42 @@ class Executor {
     executor.silent_dependent_async([](){ printf("B\n"); })
   };
   auto [C, fuC] = executor.dependent_async(
-    [](){ 
-      printf("C runs after A and B\n"); 
+    [](){
+      printf("C runs after A and B\n");
       return 1;
-    }, 
+    },
     array.begin(), array.end()
   );
   assert(fuC.get()==1);  // C finishes, which in turns means both A and B finish
   @endcode
 
-  You can mixed the use of tf::AsyncTask handles 
+  You can mixed the use of tf::AsyncTask handles
   returned by Executor::dependent_async and Executor::silent_dependent_async
   when specifying task dependencies.
 
   This member function is thread-safe.
   */
-  template <typename F, typename I,
-    std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
-  >
-  auto dependent_async(F&& func, I first, I last);
-  
-  /**
-  @brief runs the given function asynchronously 
+    template <typename F, typename I,
+             std::enable_if_t<!std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
+             >
+    auto dependent_async(F&& func, I first, I last);
+
+    /**
+  @brief runs the given function asynchronously
          when the given range of predecessors finish
-  
+
   @tparam P task parameters type
   @tparam F callable type
-  @tparam I iterator type 
-  
+  @tparam I iterator type
+
   @param params task parameters
   @param func callable object
   @param first iterator to the beginning (inclusive)
   @param last iterator to the end (exclusive)
-  
-  @return a pair of a tf::AsyncTask handle and 
+
+  @return a pair of a tf::AsyncTask handle and
                     a @std_future that holds the result of the execution
-  
+
   The example below creates three named asynchronous tasks, @c A, @c B, and @c C,
   in which task @c C runs after task @c A and task @c B.
   Task @c C returns a pair of its tf::AsyncTask handle and a std::future<int>
@@ -1044,105 +1044,105 @@ class Executor {
   };
   auto [C, fuC] = executor.dependent_async(
     "C",
-    [](){ 
-      printf("C runs after A and B\n"); 
+    [](){
+      printf("C runs after A and B\n");
       return 1;
-    }, 
+    },
     array.begin(), array.end()
   );
   assert(fuC.get()==1);  // C finishes, which in turns means both A and B finish
   @endcode
 
-  You can mixed the use of tf::AsyncTask handles 
+  You can mixed the use of tf::AsyncTask handles
   returned by Executor::dependent_async and Executor::silent_dependent_async
   when specifying task dependencies.
 
   This member function is thread-safe.
   */
-  template <typename P, typename F, typename I,
-    std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
-  >
-  auto dependent_async(P&& params, F&& func, I first, I last);
+    template <typename P, typename F, typename I,
+             std::enable_if_t<is_task_params_v<P> && !std::is_same_v<std::decay_t<I>, AsyncTask>, void>* = nullptr
+             >
+    auto dependent_async(P&& params, F&& func, I first, I last);
 
-  private:
-    
-  std::mutex _taskflows_mutex;
-  
-  std::vector<Worker> _workers;
-  DefaultNotifier _notifier;
+private:
+
+    std::mutex _taskflows_mutex;
+
+    std::vector<Worker> _workers;
+    DefaultNotifier _notifier;
 
 #if __cplusplus >= TF_CPP20
-  std::atomic<size_t> _num_topologies {0};
+    std::atomic<size_t> _num_topologies {0};
 #else
-  std::condition_variable _topology_cv;
-  std::mutex _topology_mutex;
-  size_t _num_topologies {0};
+    std::condition_variable _topology_cv;
+    std::mutex _topology_mutex;
+    size_t _num_topologies {0};
 #endif
-  
-  std::list<Taskflow> _taskflows;
 
-  Freelist<Node*> _buffers;
+    std::list<Taskflow> _taskflows;
 
-  std::shared_ptr<WorkerInterface> _worker_interface;
-  std::unordered_set<std::shared_ptr<ObserverInterface>> _observers;
+    Freelist<Node*> _buffers;
 
-  void _shutdown();
-  void _observer_prologue(Worker&, Node*);
-  void _observer_epilogue(Worker&, Node*);
-  void _spawn(size_t);
-  void _exploit_task(Worker&, Node*&);
-  bool _explore_task(Worker&, Node*&);
-  void _schedule(Worker&, Node*);
-  void _schedule(Node*);
-  void _set_up_topology(Worker*, Topology*);
-  void _tear_down_topology(Worker&, Topology*);
-  void _tear_down_async(Worker&, Node*, Node*&);
-  void _tear_down_dependent_async(Worker&, Node*, Node*&);
-  void _tear_down_invoke(Worker&, Node*, Node*&);
-  void _increment_topology();
-  void _decrement_topology();
-  void _invoke(Worker&, Node*);
-  void _invoke_static_task(Worker&, Node*);
-  void _invoke_condition_task(Worker&, Node*, SmallVector<int>&);
-  void _invoke_multi_condition_task(Worker&, Node*, SmallVector<int>&);
-  void _process_dependent_async(Node*, tf::AsyncTask&, size_t&);
-  void _process_exception(Worker&, Node*);
-  void _schedule_async_task(Node*);
-  void _update_cache(Worker&, Node*&, Node*);
+    std::shared_ptr<WorkerInterface> _worker_interface;
+    std::unordered_set<std::shared_ptr<ObserverInterface>> _observers;
 
-  bool _wait_for_task(Worker&, Node*&);
-  bool _invoke_subflow_task(Worker&, Node*);
-  bool _invoke_module_task(Worker&, Node*);
-  bool _invoke_module_task_impl(Worker&, Node*, Graph&);
-  bool _invoke_async_task(Worker&, Node*);
-  bool _invoke_dependent_async_task(Worker&, Node*);
-  bool _invoke_runtime_task(Worker&, Node*);
-  bool _invoke_runtime_task_impl(Worker&, Node*, std::function<void(Runtime&)>&);
-  bool _invoke_runtime_task_impl(Worker&, Node*, std::function<void(Runtime&, bool)>&);
+    void _shutdown();
+    void _observer_prologue(Worker&, Node*);
+    void _observer_epilogue(Worker&, Node*);
+    void _spawn(size_t);
+    void _exploit_task(Worker&, Node*&);
+    bool _explore_task(Worker&, Node*&);
+    void _schedule(Worker&, Node*);
+    void _schedule(Node*);
+    void _set_up_topology(Worker*, Topology*);
+    void _tear_down_topology(Worker&, Topology*);
+    void _tear_down_async(Worker&, Node*, Node*&);
+    void _tear_down_dependent_async(Worker&, Node*, Node*&);
+    void _tear_down_invoke(Worker&, Node*, Node*&);
+    void _increment_topology();
+    void _decrement_topology();
+    void _invoke(Worker&, Node*);
+    void _invoke_static_task(Worker&, Node*);
+    void _invoke_condition_task(Worker&, Node*, SmallVector<int>&);
+    void _invoke_multi_condition_task(Worker&, Node*, SmallVector<int>&);
+    void _process_dependent_async(Node*, tf::AsyncTask&, size_t&);
+    void _process_exception(Worker&, Node*);
+    void _schedule_async_task(Node*);
+    void _update_cache(Worker&, Node*&, Node*);
 
-  template <typename I>
-  I _set_up_graph(I, I, Topology*, Node*);
-  
-  template <typename P>
-  void _corun_until(Worker&, P&&);
-  
-  template <typename I>
-  void _corun_graph(Worker&, Node*, I, I);
+    bool _wait_for_task(Worker&, Node*&);
+    bool _invoke_subflow_task(Worker&, Node*);
+    bool _invoke_module_task(Worker&, Node*);
+    bool _invoke_module_task_impl(Worker&, Node*, Graph&);
+    bool _invoke_async_task(Worker&, Node*);
+    bool _invoke_dependent_async_task(Worker&, Node*);
+    bool _invoke_runtime_task(Worker&, Node*);
+    bool _invoke_runtime_task_impl(Worker&, Node*, WorkHandle<void(Runtime&)>&);
+    bool _invoke_runtime_task_impl(Worker&, Node*, std::function<void(Runtime&, bool)>&);
 
-  template <typename I>
-  void _schedule(Worker&, I, I);
+    template <typename I>
+    I _set_up_graph(I, I, Topology*, Node*);
 
-  template <typename I>
-  void _schedule(I, I);
+    template <typename P>
+    void _corun_until(Worker&, P&&);
 
-  template <typename I>
-  void _schedule_graph_with_parent(Worker&, I, I, Node*);
+    template <typename I>
+    void _corun_graph(Worker&, Node*, I, I);
 
-  template <typename P, typename F>
-  auto _async(P&&, F&&, Topology*, Node*);
+    template <typename I>
+    void _schedule(Worker&, I, I);
 
-  template <typename P, typename F>
-  void _silent_async(P&&, F&&, Topology*, Node*);
+    template <typename I>
+    void _schedule(I, I);
+
+    template <typename I>
+    void _schedule_graph_with_parent(Worker&, I, I, Node*);
+
+    template <typename P, typename F>
+    auto _async(P&&, F&&, Topology*, Node*);
+
+    template <typename P, typename F>
+    void _silent_async(P&&, F&&, Topology*, Node*);
 
 };
 
@@ -1150,1155 +1150,1155 @@ class Executor {
 
 // Constructor
 inline Executor::Executor(size_t N, std::shared_ptr<WorkerInterface> wix) :
-  _workers  (N),
-  _notifier (N),
-  _buffers  (N),
-  _worker_interface(std::move(wix)) {
+    _workers  (N),
+    _notifier (N),
+    _buffers  (N),
+    _worker_interface(std::move(wix)) {
 
-  if(N == 0) {
-    TF_THROW("executor must define at least one worker");
-  }
-  
-  // If spawning N threads fails, shut down any created threads before 
-  // rethrowing the exception.
+    if(N == 0) {
+        TF_THROW("executor must define at least one worker");
+    }
+
+    // If spawning N threads fails, shut down any created threads before
+    // rethrowing the exception.
 #ifndef TF_DISABLE_EXCEPTION_HANDLING
-  try {
+    try {
 #endif
-    _spawn(N);
+        _spawn(N);
 #ifndef TF_DISABLE_EXCEPTION_HANDLING
-  }
-  catch(...) {
-    _shutdown();
-    std::rethrow_exception(std::current_exception());
-  }
+    }
+    catch(...) {
+        _shutdown();
+        std::rethrow_exception(std::current_exception());
+    }
 #endif
 
-  // initialize the default observer if requested
-  if(has_env(TF_ENABLE_PROFILER)) {
-    TFProfManager::get()._manage(make_observer<TFProfObserver>());
-  }
+    // initialize the default observer if requested
+    if(has_env(TF_ENABLE_PROFILER)) {
+        TFProfManager::get()._manage(make_observer<TFProfObserver>());
+    }
 }
 
 // Destructor
 inline Executor::~Executor() {
-  _shutdown();
+    _shutdown();
 }
 
 // Function: _shutdown
 inline void Executor::_shutdown() {
 
-  // wait for all topologies to complete
-  wait_for_all();
+    // wait for all topologies to complete
+    wait_for_all();
 
-  // shut down the scheduler
-  for(size_t i=0; i<_workers.size(); ++i) {
-  #if __cplusplus >= TF_CPP20
-    _workers[i]._done.test_and_set(std::memory_order_relaxed);
-  #else
-    _workers[i]._done.store(true, std::memory_order_relaxed);
-  #endif
-  }
-  
-  _notifier.notify_all();
-  
-  // Only join the thread if it is joinable, as std::thread construction 
-  // may fail and throw an exception.
-  for(auto& w : _workers) {
-    if(w._thread.joinable()) {
-      w._thread.join();
+    // shut down the scheduler
+    for(size_t i=0; i<_workers.size(); ++i) {
+#if __cplusplus >= TF_CPP20
+        _workers[i]._done.test_and_set(std::memory_order_relaxed);
+#else
+        _workers[i]._done.store(true, std::memory_order_relaxed);
+#endif
     }
-  }
+
+    _notifier.notify_all();
+
+    // Only join the thread if it is joinable, as std::thread construction
+    // may fail and throw an exception.
+    for(auto& w : _workers) {
+        if(w._thread.joinable()) {
+            w._thread.join();
+        }
+    }
 }
 
 // Function: num_workers
 inline size_t Executor::num_workers() const noexcept {
-  return _workers.size();
+    return _workers.size();
 }
 
 // Function: num_waiters
 inline size_t Executor::num_waiters() const noexcept {
 #if __cplusplus >= TF_CPP20
-  return _notifier.num_waiters();
+    return _notifier.num_waiters();
 #else
-  // Unfortunately, nonblocking notifier does not have an easy way to return
-  // the number of workers that are not making stealing attempts.
-  return 0;
+    // Unfortunately, nonblocking notifier does not have an easy way to return
+    // the number of workers that are not making stealing attempts.
+    return 0;
 #endif
 }
 
 // Function: num_queues
 inline size_t Executor::num_queues() const noexcept {
-  return _workers.size() + _buffers.size();
+    return _workers.size() + _buffers.size();
 }
 
 // Function: num_topologies
 inline size_t Executor::num_topologies() const {
 #if __cplusplus >= TF_CPP20
-  return _num_topologies.load(std::memory_order_relaxed);
+    return _num_topologies.load(std::memory_order_relaxed);
 #else
-  return _num_topologies;
+    return _num_topologies;
 #endif
 }
 
 // Function: num_taskflows
 inline size_t Executor::num_taskflows() const {
-  return _taskflows.size();
+    return _taskflows.size();
 }
 
 // Function: this_worker_id
 inline int Executor::this_worker_id() const {
-  auto w = pt::this_worker;
-  return (w && w->_executor == this) ? static_cast<int>(w->_id) : -1;
+    auto w = pt::this_worker;
+    return (w && w->_executor == this) ? static_cast<int>(w->_id) : -1;
 }
 
 // Procedure: _spawn
 inline void Executor::_spawn(size_t N) {
 
-  for(size_t id=0; id<N; ++id) {
-    _workers[id]._id = id;
-    _workers[id]._vtm = id;
-    _workers[id]._executor = this;
-    _workers[id]._waiter = &_notifier._waiters[id];
-    _workers[id]._thread = std::thread([&, &w=_workers[id]] () {
+    for(size_t id=0; id<N; ++id) {
+        _workers[id]._id = id;
+        _workers[id]._vtm = id;
+        _workers[id]._executor = this;
+        _workers[id]._waiter = &_notifier._waiters[id];
+        _workers[id]._thread = std::thread([&, &w=_workers[id]] () {
 
-      pt::this_worker = &w;
+            pt::this_worker = &w;
 
-      // initialize the random engine and seed for work-stealing loop
-      w._rdgen.seed(static_cast<std::default_random_engine::result_type>(
-        std::hash<std::thread::id>()(std::this_thread::get_id()))
-      );
+            // initialize the random engine and seed for work-stealing loop
+            w._rdgen.seed(static_cast<std::default_random_engine::result_type>(
+                std::hash<std::thread::id>()(std::this_thread::get_id()))
+                          );
 
-      // before entering the work-stealing loop, call the scheduler prologue
-      if(_worker_interface) {
-        _worker_interface->scheduler_prologue(w);
-      }
+            // before entering the work-stealing loop, call the scheduler prologue
+            if(_worker_interface) {
+                _worker_interface->scheduler_prologue(w);
+            }
 
-      Node* t = nullptr;
-      std::exception_ptr ptr = nullptr;
+            Node* t = nullptr;
+            std::exception_ptr ptr = nullptr;
 
-      // must use 1 as condition instead of !done because
-      // the previous worker may stop while the following workers
-      // are still preparing for entering the scheduling loop
+// must use 1 as condition instead of !done because
+// the previous worker may stop while the following workers
+// are still preparing for entering the scheduling loop
 #ifndef TF_DISABLE_EXCEPTION_HANDLING
-      try {
+            try {
 #endif
 
-        // worker loop
-        while(1) {
+                // worker loop
+                while(1) {
 
-          // drain out the local queue
-          _exploit_task(w, t);
+                    // drain out the local queue
+                    _exploit_task(w, t);
 
-          // steal and wait for tasks
-          if(_wait_for_task(w, t) == false) {
-            break;
-          }
-        }
+                    // steal and wait for tasks
+                    if(_wait_for_task(w, t) == false) {
+                        break;
+                    }
+                }
 
 #ifndef TF_DISABLE_EXCEPTION_HANDLING
-      } 
-      catch(...) {
-        ptr = std::current_exception();
-      }
+            }
+            catch(...) {
+                ptr = std::current_exception();
+            }
 #endif
-      
-      // call the user-specified epilogue function
-      if(_worker_interface) {
-        _worker_interface->scheduler_epilogue(w, ptr);
-      }
 
-    });
-  } 
+            // call the user-specified epilogue function
+            if(_worker_interface) {
+                _worker_interface->scheduler_epilogue(w, ptr);
+            }
+
+        });
+    }
 }
 
 // Function: _corun_until
 template <typename P>
 void Executor::_corun_until(Worker& w, P&& stop_predicate) {
 
-  const size_t MAX_STEALS = ((num_queues() + 1) << 1);
-    
-  std::uniform_int_distribution<size_t> udist(0, num_queues()-1);
-  
-  exploit:
+    const size_t MAX_STEALS = ((num_queues() + 1) << 1);
 
-  while(!stop_predicate()) {
-    
-    // here we don't do while-loop to drain out the local queue as it can
-    // potentially enter a very deep recursive corun, cuasing stack overflow
-    if(auto t = w._wsq.pop(); t) {
-      _invoke(w, t);
-    }
-    else {
-      size_t num_steals = 0;
-      size_t vtm = w._vtm;
+    std::uniform_int_distribution<size_t> udist(0, num_queues()-1);
 
-      explore:
+exploit:
 
-      t = (vtm < _workers.size()) ? _workers[vtm]._wsq.steal() : 
-                                    _buffers.steal(vtm - _workers.size());
+    while(!stop_predicate()) {
 
-      if(t) {
-        _invoke(w, t);
-        w._vtm = vtm;
-        goto exploit;
-      }
-      else if(!stop_predicate()) {
-        if(++num_steals > MAX_STEALS) {
-          std::this_thread::yield();
+        // here we don't do while-loop to drain out the local queue as it can
+        // potentially enter a very deep recursive corun, cuasing stack overflow
+        if(auto t = w._wsq.pop(); t) {
+            _invoke(w, t);
         }
-        vtm = udist(w._rdgen);
-        goto explore;
-      }
-      else {
-        break;
-      }
+        else {
+            size_t num_steals = 0;
+            size_t vtm = w._vtm;
+
+        explore:
+
+            t = (vtm < _workers.size()) ? _workers[vtm]._wsq.steal() :
+                    _buffers.steal(vtm - _workers.size());
+
+            if(t) {
+                _invoke(w, t);
+                w._vtm = vtm;
+                goto exploit;
+            }
+            else if(!stop_predicate()) {
+                if(++num_steals > MAX_STEALS) {
+                    std::this_thread::yield();
+                }
+                vtm = udist(w._rdgen);
+                goto explore;
+            }
+            else {
+                break;
+            }
+        }
     }
-  }
 }
 
 // Function: _explore_task
 inline bool Executor::_explore_task(Worker& w, Node*& t) {
 
-  //assert(!t);
-  
-  const size_t MAX_STEALS = ((num_queues() + 1) << 1);
-  std::uniform_int_distribution<size_t> udist(0, num_queues()-1);
+    //assert(!t);
 
-  size_t num_steals = 0;
-  size_t vtm = w._vtm;
+    const size_t MAX_STEALS = ((num_queues() + 1) << 1);
+    std::uniform_int_distribution<size_t> udist(0, num_queues()-1);
 
-  // Make the worker steal immediately from the assigned victim.
-  while(true) {
-    
-    // If the worker's victim thread is within the worker pool, steal from the worker's queue.
-    // Otherwise, steal from the buffer, adjusting the victim index based on the worker pool size.
-    t = (vtm < _workers.size())
-      ? _workers[vtm]._wsq.steal()
-      : _buffers.steal(vtm - _workers.size());
+    size_t num_steals = 0;
+    size_t vtm = w._vtm;
 
-    if(t) {
-      w._vtm = vtm;
-      break;
+    // Make the worker steal immediately from the assigned victim.
+    while(true) {
+
+        // If the worker's victim thread is within the worker pool, steal from the worker's queue.
+        // Otherwise, steal from the buffer, adjusting the victim index based on the worker pool size.
+        t = (vtm < _workers.size())
+                ? _workers[vtm]._wsq.steal()
+                : _buffers.steal(vtm - _workers.size());
+
+        if(t) {
+            w._vtm = vtm;
+            break;
+        }
+
+        // Increment the steal count, and if it exceeds MAX_STEALS, yield the thread.
+        // If the number of *consecutive* empty steals reaches MAX_STEALS, exit the loop.
+        if (++num_steals > MAX_STEALS) {
+            std::this_thread::yield();
+            if(num_steals > 100 + MAX_STEALS) {
+                break;
+            }
+        }
+
+#if __cplusplus >= TF_CPP20
+        if(w._done.test(std::memory_order_relaxed)) {
+#else
+        if(w._done.load(std::memory_order_relaxed)) {
+#endif
+            return false;
+        }
+
+        // Randomely generate a next victim.
+        vtm = udist(w._rdgen); //w._rdvtm();
     }
-
-    // Increment the steal count, and if it exceeds MAX_STEALS, yield the thread.
-    // If the number of *consecutive* empty steals reaches MAX_STEALS, exit the loop.
-    if (++num_steals > MAX_STEALS) {
-      std::this_thread::yield();
-      if(num_steals > 100 + MAX_STEALS) {
-        break;
-      }
-    }
-
-  #if __cplusplus >= TF_CPP20
-    if(w._done.test(std::memory_order_relaxed)) {
-  #else
-    if(w._done.load(std::memory_order_relaxed)) {
-  #endif
-      return false;
-    } 
-
-    // Randomely generate a next victim.
-    vtm = udist(w._rdgen); //w._rdvtm();
-  } 
-  return true;
+    return true;
 }
 
 // Procedure: _exploit_task
 inline void Executor::_exploit_task(Worker& w, Node*& t) {
-  while(t) {
-    _invoke(w, t);
-    t = w._wsq.pop();
-  }
+    while(t) {
+        _invoke(w, t);
+        t = w._wsq.pop();
+    }
 }
 
 // Function: _wait_for_task
 inline bool Executor::_wait_for_task(Worker& w, Node*& t) {
 
-  explore_task:
+explore_task:
 
-  if(_explore_task(w, t) == false) {
-    return false;
-  }
-  
-  // Go exploit the task if we successfully steal one.
-  if(t) {
-    return true;
-  }
+    if(_explore_task(w, t) == false) {
+        return false;
+    }
 
-  // Entering the 2PC guard as all queues should be empty after many stealing attempts.
-  _notifier.prepare_wait(w._waiter);
-  
-  // Condition #1: buffers should be empty
-  for(size_t vtm=0; vtm<_buffers.size(); ++vtm) {
-    if(!_buffers._buckets[vtm].queue.empty()) {
-      _notifier.cancel_wait(w._waiter);
-      w._vtm = vtm + _workers.size();
-      goto explore_task;
+    // Go exploit the task if we successfully steal one.
+    if(t) {
+        return true;
     }
-  }
-  
-  // Condition #2: worker queues should be empty
-  // Note: We need to use index-based looping to avoid data race with _spawan
-  // which initializes other worker data structure at the same time
-  for(size_t vtm=0; vtm<w._id; ++vtm) {
-    if(!_workers[vtm]._wsq.empty()) {
-      _notifier.cancel_wait(w._waiter);
-      w._vtm = vtm;
-      goto explore_task;
+
+    // Entering the 2PC guard as all queues should be empty after many stealing attempts.
+    _notifier.prepare_wait(w._waiter);
+
+    // Condition #1: buffers should be empty
+    for(size_t vtm=0; vtm<_buffers.size(); ++vtm) {
+        if(!_buffers._buckets[vtm].queue.empty()) {
+            _notifier.cancel_wait(w._waiter);
+            w._vtm = vtm + _workers.size();
+            goto explore_task;
+        }
     }
-  }
-  
-  // due to the property of the work-stealing queue, we don't need to check
-  // the queue of this worker
-  for(size_t vtm=w._id+1; vtm<_workers.size(); vtm++) {
-    if(!_workers[vtm]._wsq.empty()) {
-      _notifier.cancel_wait(w._waiter);
-      w._vtm = vtm;
-      goto explore_task;
+
+    // Condition #2: worker queues should be empty
+    // Note: We need to use index-based looping to avoid data race with _spawan
+    // which initializes other worker data structure at the same time
+    for(size_t vtm=0; vtm<w._id; ++vtm) {
+        if(!_workers[vtm]._wsq.empty()) {
+            _notifier.cancel_wait(w._waiter);
+            w._vtm = vtm;
+            goto explore_task;
+        }
     }
-  }
-  
-  // Condition #3: worker should be alive
+
+    // due to the property of the work-stealing queue, we don't need to check
+    // the queue of this worker
+    for(size_t vtm=w._id+1; vtm<_workers.size(); vtm++) {
+        if(!_workers[vtm]._wsq.empty()) {
+            _notifier.cancel_wait(w._waiter);
+            w._vtm = vtm;
+            goto explore_task;
+        }
+    }
+
+    // Condition #3: worker should be alive
 #if __cplusplus >= TF_CPP20
-  if(w._done.test(std::memory_order_relaxed)) {
+    if(w._done.test(std::memory_order_relaxed)) {
 #else
-  if(w._done.load(std::memory_order_relaxed)) {
+    if(w._done.load(std::memory_order_relaxed)) {
 #endif
-    _notifier.cancel_wait(w._waiter);
-    return false;
-  }
-  
-  // Now I really need to relinquish myself to others.
-  _notifier.commit_wait(w._waiter);
-  goto explore_task;
+        _notifier.cancel_wait(w._waiter);
+        return false;
+    }
+
+    // Now I really need to relinquish myself to others.
+    _notifier.commit_wait(w._waiter);
+    goto explore_task;
 }
 
 // Function: make_observer
 template<typename Observer, typename... ArgsT>
 std::shared_ptr<Observer> Executor::make_observer(ArgsT&&... args) {
 
-  static_assert(
-    std::is_base_of_v<ObserverInterface, Observer>,
-    "Observer must be derived from ObserverInterface"
-  );
+    static_assert(
+        std::is_base_of_v<ObserverInterface, Observer>,
+        "Observer must be derived from ObserverInterface"
+        );
 
-  // use a local variable to mimic the constructor
-  auto ptr = std::make_shared<Observer>(std::forward<ArgsT>(args)...);
+    // use a local variable to mimic the constructor
+    auto ptr = std::make_shared<Observer>(std::forward<ArgsT>(args)...);
 
-  ptr->set_up(_workers.size());
+    ptr->set_up(_workers.size());
 
-  _observers.emplace(std::static_pointer_cast<ObserverInterface>(ptr));
+    _observers.emplace(std::static_pointer_cast<ObserverInterface>(ptr));
 
-  return ptr;
+    return ptr;
 }
 
 // Procedure: remove_observer
 template <typename Observer>
 void Executor::remove_observer(std::shared_ptr<Observer> ptr) {
 
-  static_assert(
-    std::is_base_of_v<ObserverInterface, Observer>,
-    "Observer must be derived from ObserverInterface"
-  );
+    static_assert(
+        std::is_base_of_v<ObserverInterface, Observer>,
+        "Observer must be derived from ObserverInterface"
+        );
 
-  _observers.erase(std::static_pointer_cast<ObserverInterface>(ptr));
+    _observers.erase(std::static_pointer_cast<ObserverInterface>(ptr));
 }
 
 // Function: num_observers
 inline size_t Executor::num_observers() const noexcept {
-  return _observers.size();
+    return _observers.size();
 }
 
 // Procedure: _schedule
 inline void Executor::_schedule(Worker& worker, Node* node) {
-  
-  // caller is a worker of this executor - starting at v3.5 we do not use
-  // any complicated notification mechanism as the experimental result
-  // has shown no significant advantage.
-  if(worker._executor == this) {
-    worker._wsq.push(node, [&](){ _buffers.push(node); });
+
+    // caller is a worker of this executor - starting at v3.5 we do not use
+    // any complicated notification mechanism as the experimental result
+    // has shown no significant advantage.
+    if(worker._executor == this) {
+        worker._wsq.push(node, [&](){ _buffers.push(node); });
+        _notifier.notify_one();
+        return;
+    }
+
+    // caller is not a worker of this executor - go through the centralized queue
+    _buffers.push(node);
     _notifier.notify_one();
-    return;
-  }
-  
-  // caller is not a worker of this executor - go through the centralized queue
-  _buffers.push(node);
-  _notifier.notify_one();
 }
 
 // Procedure: _schedule
 inline void Executor::_schedule(Node* node) {
-  _buffers.push(node);
-  _notifier.notify_one();
+    _buffers.push(node);
+    _notifier.notify_one();
 }
 
 // Procedure: _schedule
 template <typename I>
 void Executor::_schedule(Worker& worker, I first, I last) {
 
-  size_t num_nodes = last - first;
-  
-  if(num_nodes == 0) {
-    return;
-  }
-  
-  // NOTE: We cannot use first/last in the for-loop (e.g., for(; first != last; ++first)).
-  // This is because when a node v is inserted into the queue, v can run and finish 
-  // immediately. If v is the last node in the graph, it will tear down the parent task vector
-  // which cause the last ++first to fail. This problem is specific to MSVC which has a stricter
-  // iterator implementation in std::vector than GCC/Clang.
-  if(worker._executor == this) {
-    for(size_t i=0; i<num_nodes; i++) {
-      auto node = detail::get_node_ptr(first[i]);
-      worker._wsq.push(node, [&](){ _buffers.push(node); });
-      _notifier.notify_one();
+    size_t num_nodes = last - first;
+
+    if(num_nodes == 0) {
+        return;
     }
-    return;
-  }
-  
-  // caller is not a worker of this executor - go through the centralized queue
-  for(size_t i=0; i<num_nodes; i++) {
-    _buffers.push(detail::get_node_ptr(first[i]));
-  }
-  _notifier.notify_n(num_nodes);
+
+    // NOTE: We cannot use first/last in the for-loop (e.g., for(; first != last; ++first)).
+    // This is because when a node v is inserted into the queue, v can run and finish
+    // immediately. If v is the last node in the graph, it will tear down the parent task vector
+    // which cause the last ++first to fail. This problem is specific to MSVC which has a stricter
+    // iterator implementation in std::vector than GCC/Clang.
+    if(worker._executor == this) {
+        for(size_t i=0; i<num_nodes; i++) {
+            auto node = detail::get_node_ptr(first[i]);
+            worker._wsq.push(node, [&](){ _buffers.push(node); });
+            _notifier.notify_one();
+        }
+        return;
+    }
+
+    // caller is not a worker of this executor - go through the centralized queue
+    for(size_t i=0; i<num_nodes; i++) {
+        _buffers.push(detail::get_node_ptr(first[i]));
+    }
+    _notifier.notify_n(num_nodes);
 }
 
 // Procedure: _schedule
 template <typename I>
 inline void Executor::_schedule(I first, I last) {
-  
-  size_t num_nodes = last - first;
 
-  if(num_nodes == 0) {
-    return;
-  }
+    size_t num_nodes = last - first;
 
-  // NOTE: We cannot use first/last in the for-loop (e.g., for(; first != last; ++first)).
-  // This is because when a node v is inserted into the queue, v can run and finish 
-  // immediately. If v is the last node in the graph, it will tear down the parent task vector
-  // which cause the last ++first to fail. This problem is specific to MSVC which has a stricter
-  // iterator implementation in std::vector than GCC/Clang.
-  for(size_t i=0; i<num_nodes; i++) {
-    _buffers.push(detail::get_node_ptr(first[i]));
-  }
-  _notifier.notify_n(num_nodes);
+    if(num_nodes == 0) {
+        return;
+    }
+
+    // NOTE: We cannot use first/last in the for-loop (e.g., for(; first != last; ++first)).
+    // This is because when a node v is inserted into the queue, v can run and finish
+    // immediately. If v is the last node in the graph, it will tear down the parent task vector
+    // which cause the last ++first to fail. This problem is specific to MSVC which has a stricter
+    // iterator implementation in std::vector than GCC/Clang.
+    for(size_t i=0; i<num_nodes; i++) {
+        _buffers.push(detail::get_node_ptr(first[i]));
+    }
+    _notifier.notify_n(num_nodes);
 }
-  
+
 template <typename I>
 void Executor::_schedule_graph_with_parent(Worker& worker, I beg, I end, Node* parent) {
-  auto send = _set_up_graph(beg, end, parent->_topology, parent);
-  parent->_join_counter.fetch_add(send - beg, std::memory_order_relaxed);
-  _schedule(worker, beg, send);
+    auto send = _set_up_graph(beg, end, parent->_topology, parent);
+    parent->_join_counter.fetch_add(send - beg, std::memory_order_relaxed);
+    _schedule(worker, beg, send);
 }
 
 TF_FORCE_INLINE void Executor::_update_cache(Worker& worker, Node*& cache, Node* node) {
-  if(cache) {
-    _schedule(worker, cache);
-  }
-  cache = node;
+    if(cache) {
+        _schedule(worker, cache);
+    }
+    cache = node;
 }
-  
+
 // Procedure: _invoke
 inline void Executor::_invoke(Worker& worker, Node* node) {
 
-  #define TF_INVOKE_CONTINUATION()  \
-  if (cache) {                      \
-    node = cache;                   \
-    goto begin_invoke;              \
-  }
-
-  begin_invoke:
-
-  Node* cache {nullptr};
-  
-  // if this is the second invoke due to preemption, directly jump to invoke task
-  if(node->_nstate & NSTATE::PREEMPTED) {
-    goto invoke_task;
-  }
-
-  // if the work has been cancelled, there is no need to continue
-  if(node->_is_cancelled()) {
-    _tear_down_invoke(worker, node, cache);
-    TF_INVOKE_CONTINUATION();
-    return;
-  }
-
-  // if acquiring semaphore(s) exists, acquire them first
-  if(node->_semaphores && !node->_semaphores->to_acquire.empty()) {
-    SmallVector<Node*> waiters;
-    if(!node->_acquire_all(waiters)) {
-      _schedule(worker, waiters.begin(), waiters.end());
-      return;
+#define TF_INVOKE_CONTINUATION()  \
+    if (cache) {                      \
+            node = cache;                   \
+            goto begin_invoke;              \
     }
-  }
-  
-  invoke_task:
-  
-  SmallVector<int> conds;
 
-  // switch is faster than nested if-else due to jump table
-  switch(node->_handle.index()) {
+begin_invoke:
+
+    Node* cache {nullptr};
+
+    // if this is the second invoke due to preemption, directly jump to invoke task
+    if(node->_nstate & NSTATE::PREEMPTED) {
+        goto invoke_task;
+    }
+
+    // if the work has been cancelled, there is no need to continue
+    if(node->_is_cancelled()) {
+        _tear_down_invoke(worker, node, cache);
+        TF_INVOKE_CONTINUATION();
+        return;
+    }
+
+    // if acquiring semaphore(s) exists, acquire them first
+    if(node->_semaphores && !node->_semaphores->to_acquire.empty()) {
+        SmallVector<Node*> waiters;
+        if(!node->_acquire_all(waiters)) {
+            _schedule(worker, waiters.begin(), waiters.end());
+            return;
+        }
+    }
+
+invoke_task:
+
+    SmallVector<int> conds;
+
+    // switch is faster than nested if-else due to jump table
+    switch(node->_handle.index()) {
     // static task
     case Node::STATIC:{
-      _invoke_static_task(worker, node);
+        _invoke_static_task(worker, node);
     }
     break;
-    
+
     // runtime task
     case Node::RUNTIME:{
-      if(_invoke_runtime_task(worker, node)) {
-        return;
-      }
+        if(_invoke_runtime_task(worker, node)) {
+            return;
+        }
     }
     break;
 
-    // subflow task
+        // subflow task
     case Node::SUBFLOW: {
-      if(_invoke_subflow_task(worker, node)) {
-        return;
-      }
+        if(_invoke_subflow_task(worker, node)) {
+            return;
+        }
     }
     break;
 
-    // condition task
+        // condition task
     case Node::CONDITION: {
-      _invoke_condition_task(worker, node, conds);
+        _invoke_condition_task(worker, node, conds);
     }
     break;
 
-    // multi-condition task
+        // multi-condition task
     case Node::MULTI_CONDITION: {
-      _invoke_multi_condition_task(worker, node, conds);
+        _invoke_multi_condition_task(worker, node, conds);
     }
     break;
 
-    // module task
+        // module task
     case Node::MODULE: {
-      if(_invoke_module_task(worker, node)) {
-        return;
-      }
+        if(_invoke_module_task(worker, node)) {
+            return;
+        }
     }
     break;
 
-    // async task
+        // async task
     case Node::ASYNC: {
-      if(_invoke_async_task(worker, node)) {
+        if(_invoke_async_task(worker, node)) {
+            return;
+        }
+        _tear_down_async(worker, node, cache);
+        TF_INVOKE_CONTINUATION();
         return;
-      }
-      _tear_down_async(worker, node, cache);
-      TF_INVOKE_CONTINUATION();
-      return;
     }
     break;
 
-    // dependent async task
+        // dependent async task
     case Node::DEPENDENT_ASYNC: {
-      if(_invoke_dependent_async_task(worker, node)) {
+        if(_invoke_dependent_async_task(worker, node)) {
+            return;
+        }
+        _tear_down_dependent_async(worker, node, cache);
+        TF_INVOKE_CONTINUATION();
         return;
-      }
-      _tear_down_dependent_async(worker, node, cache);
-      TF_INVOKE_CONTINUATION();
-      return;
     }
     break;
 
-    // monostate (placeholder)
+        // monostate (placeholder)
     default:
-    break;
-  }
+        break;
+    }
 
-  // if releasing semaphores exist, release them
-  if(node->_semaphores && !node->_semaphores->to_release.empty()) {
-    SmallVector<Node*> waiters;
-    node->_release_all(waiters);
-    _schedule(worker, waiters.begin(), waiters.end());
-  }
+    // if releasing semaphores exist, release them
+    if(node->_semaphores && !node->_semaphores->to_release.empty()) {
+        SmallVector<Node*> waiters;
+        node->_release_all(waiters);
+        _schedule(worker, waiters.begin(), waiters.end());
+    }
 
-  // Reset the join counter with strong dependencies to support cycles.
-  // + We must do this before scheduling the successors to avoid race
-  //   condition on _predecessors.
-  // + We must use fetch_add instead of direct assigning
-  //   because the user-space call on "invoke" may explicitly schedule 
-  //   this task again (e.g., pipeline) which can access the join_counter.
-  node->_join_counter.fetch_add(
-    node->num_predecessors() - (node->_nstate & ~NSTATE::MASK), std::memory_order_relaxed
-  );
+    // Reset the join counter with strong dependencies to support cycles.
+    // + We must do this before scheduling the successors to avoid race
+    //   condition on _predecessors.
+    // + We must use fetch_add instead of direct assigning
+    //   because the user-space call on "invoke" may explicitly schedule
+    //   this task again (e.g., pipeline) which can access the join_counter.
+    node->_join_counter.fetch_add(
+        node->num_predecessors() - (node->_nstate & ~NSTATE::MASK), std::memory_order_relaxed
+        );
 
-  // acquire the parent flow counter
-  auto& join_counter = (node->_parent) ? node->_parent->_join_counter :
-                       node->_topology->_join_counter;
+    // acquire the parent flow counter
+    auto& join_counter = (node->_parent) ? node->_parent->_join_counter :
+                             node->_topology->_join_counter;
 
-  // Invoke the task based on the corresponding type
-  switch(node->_handle.index()) {
+    // Invoke the task based on the corresponding type
+    switch(node->_handle.index()) {
 
     // condition and multi-condition tasks
     case Node::CONDITION:
     case Node::MULTI_CONDITION: {
-      for(auto cond : conds) {
-        if(cond >= 0 && static_cast<size_t>(cond) < node->_num_successors) {
-          auto s = node->_edges[cond]; 
-          // zeroing the join counter for invariant
-          s->_join_counter.store(0, std::memory_order_relaxed);
-          join_counter.fetch_add(1, std::memory_order_relaxed);
-          _update_cache(worker, cache, s);
+        for(auto cond : conds) {
+            if(cond >= 0 && static_cast<size_t>(cond) < node->_num_successors) {
+                auto s = node->_edges[cond];
+                // zeroing the join counter for invariant
+                s->_join_counter.store(0, std::memory_order_relaxed);
+                join_counter.fetch_add(1, std::memory_order_relaxed);
+                _update_cache(worker, cache, s);
+            }
         }
-      }
     }
     break;
 
-    // non-condition task
+        // non-condition task
     default: {
-      for(size_t i=0; i<node->_num_successors; ++i) {
-        if(auto s = node->_edges[i]; s->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-          join_counter.fetch_add(1, std::memory_order_relaxed);
-          _update_cache(worker, cache, s);
+        for(size_t i=0; i<node->_num_successors; ++i) {
+            if(auto s = node->_edges[i]; s->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                join_counter.fetch_add(1, std::memory_order_relaxed);
+                _update_cache(worker, cache, s);
+            }
         }
-      }
     }
     break;
-  }
-  
-  // clean up the node after execution
-  _tear_down_invoke(worker, node, cache);
-  TF_INVOKE_CONTINUATION();
+    }
+
+    // clean up the node after execution
+    _tear_down_invoke(worker, node, cache);
+    TF_INVOKE_CONTINUATION();
 }
 
 // Procedure: _tear_down_invoke
 inline void Executor::_tear_down_invoke(Worker& worker, Node* node, Node*& cache) {
-  
-  // we must check parent first before subtracting the join counter,
-  // or it can introduce data race
-  if(auto parent = node->_parent; parent == nullptr) {
-    if(node->_topology->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      _tear_down_topology(worker, node->_topology);
+
+    // we must check parent first before subtracting the join counter,
+    // or it can introduce data race
+    if(auto parent = node->_parent; parent == nullptr) {
+        if(node->_topology->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            _tear_down_topology(worker, node->_topology);
+        }
     }
-  }
-  else {  
-    // needs to fetch every data before join counter becomes zero at which
-    // the node may be deleted
-    auto state = parent->_nstate;
-    if(parent->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      if(state & NSTATE::PREEMPTED) {
-        _update_cache(worker, cache, parent);
-      }
+    else {
+        // needs to fetch every data before join counter becomes zero at which
+        // the node may be deleted
+        auto state = parent->_nstate;
+        if(parent->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            if(state & NSTATE::PREEMPTED) {
+                _update_cache(worker, cache, parent);
+            }
+        }
     }
-  }
 }
 
 // Procedure: _observer_prologue
 inline void Executor::_observer_prologue(Worker& worker, Node* node) {
-  for(auto& observer : _observers) {
-    observer->on_entry(WorkerView(worker), TaskView(*node));
-  }
+    for(auto& observer : _observers) {
+        observer->on_entry(WorkerView(worker), TaskView(*node));
+    }
 }
 
 // Procedure: _observer_epilogue
 inline void Executor::_observer_epilogue(Worker& worker, Node* node) {
-  for(auto& observer : _observers) {
-    observer->on_exit(WorkerView(worker), TaskView(*node));
-  }
+    for(auto& observer : _observers) {
+        observer->on_exit(WorkerView(worker), TaskView(*node));
+    }
 }
 
 // Procedure: _process_exception
 inline void Executor::_process_exception(Worker&, Node* node) {
 
-  constexpr static auto flag = ESTATE::EXCEPTION | ESTATE::CANCELLED;
+    constexpr static auto flag = ESTATE::EXCEPTION | ESTATE::CANCELLED;
 
-  // find the anchor and mark the entire path with exception so recursive
-  // or nested tasks can be cancelled properly
-  // since exception can come from asynchronous task (with runtime), the node
-  // itself can be anchored
-  auto anchor = node;
-  while(anchor && (anchor->_estate.load(std::memory_order_relaxed) & ESTATE::ANCHORED) == 0) {
-    anchor->_estate.fetch_or(flag, std::memory_order_relaxed);
-    anchor = anchor->_parent;
-  }
+    // find the anchor and mark the entire path with exception so recursive
+    // or nested tasks can be cancelled properly
+    // since exception can come from asynchronous task (with runtime), the node
+    // itself can be anchored
+    auto anchor = node;
+    while(anchor && (anchor->_estate.load(std::memory_order_relaxed) & ESTATE::ANCHORED) == 0) {
+        anchor->_estate.fetch_or(flag, std::memory_order_relaxed);
+        anchor = anchor->_parent;
+    }
 
-  // the exception occurs under a blocking call (e.g., corun, join)
-  if(anchor) {
-    // multiple tasks may throw, and we only take the first thrown exception
-    if((anchor->_estate.fetch_or(flag, std::memory_order_relaxed) & ESTATE::EXCEPTION) == 0) {
-      anchor->_exception_ptr = std::current_exception();
-      return;
+    // the exception occurs under a blocking call (e.g., corun, join)
+    if(anchor) {
+        // multiple tasks may throw, and we only take the first thrown exception
+        if((anchor->_estate.fetch_or(flag, std::memory_order_relaxed) & ESTATE::EXCEPTION) == 0) {
+            anchor->_exception_ptr = std::current_exception();
+            return;
+        }
     }
-  }
-  // otherwise, we simply store the exception in the topology and cancel it
-  else if(auto tpg = node->_topology; tpg) {
-    // multiple tasks may throw, and we only take the first thrown exception
-    if((tpg->_estate.fetch_or(flag, std::memory_order_relaxed) & ESTATE::EXCEPTION) == 0) {
-      tpg->_exception_ptr = std::current_exception();
-      return;
+    // otherwise, we simply store the exception in the topology and cancel it
+    else if(auto tpg = node->_topology; tpg) {
+        // multiple tasks may throw, and we only take the first thrown exception
+        if((tpg->_estate.fetch_or(flag, std::memory_order_relaxed) & ESTATE::EXCEPTION) == 0) {
+            tpg->_exception_ptr = std::current_exception();
+            return;
+        }
     }
-  }
-  
-  // for now, we simply store the exception in this node; this can happen in an 
-  // execution that does not have any external control to capture the exception,
-  // such as silent async task
-  node->_exception_ptr = std::current_exception();
+
+    // for now, we simply store the exception in this node; this can happen in an
+    // execution that does not have any external control to capture the exception,
+    // such as silent async task
+    node->_exception_ptr = std::current_exception();
 }
 
 // Procedure: _invoke_static_task
 inline void Executor::_invoke_static_task(Worker& worker, Node* node) {
-  _observer_prologue(worker, node);
-  TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-    std::get_if<Node::Static>(&node->_handle)->work();
-  });
-  _observer_epilogue(worker, node);
+    _observer_prologue(worker, node);
+    TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+        std::get_if<Node::Static>(&node->_handle)->work();
+    });
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_subflow_task
 inline bool Executor::_invoke_subflow_task(Worker& worker, Node* node) {
-    
-  auto& h = *std::get_if<Node::Subflow>(&node->_handle);
-  auto& g = h.subgraph;
 
-  if((node->_nstate & NSTATE::PREEMPTED) == 0) {
-    
-    // set up the subflow
-    Subflow sf(*this, worker, node, g);
+    auto& h = *std::get_if<Node::Subflow>(&node->_handle);
+    auto& g = h.subgraph;
 
-    // invoke the subflow callable
-    _observer_prologue(worker, node);
-    TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-      h.work(sf);
-    });
-    _observer_epilogue(worker, node);
-    
-    // spawn the subflow if it is joinable and its graph is non-empty
-    // implicit join is faster than Subflow::join as it does not involve corun
-    if(sf.joinable() && g.size()) {
+    if((node->_nstate & NSTATE::PREEMPTED) == 0) {
 
-      // signal the executor to preempt this node
-      node->_nstate |= NSTATE::PREEMPTED;
+        // set up the subflow
+        Subflow sf(*this, worker, node, g);
 
-      // set up and schedule the graph
-      _schedule_graph_with_parent(worker, g.begin(), g.end(), node);
-      return true;
+        // invoke the subflow callable
+        _observer_prologue(worker, node);
+        TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+            h.work(sf);
+        });
+        _observer_epilogue(worker, node);
+
+        // spawn the subflow if it is joinable and its graph is non-empty
+        // implicit join is faster than Subflow::join as it does not involve corun
+        if(sf.joinable() && g.size()) {
+
+            // signal the executor to preempt this node
+            node->_nstate |= NSTATE::PREEMPTED;
+
+            // set up and schedule the graph
+            _schedule_graph_with_parent(worker, g.begin(), g.end(), node);
+            return true;
+        }
     }
-  }
-  else {
-    node->_nstate &= ~NSTATE::PREEMPTED;
-  }
+    else {
+        node->_nstate &= ~NSTATE::PREEMPTED;
+    }
 
-  // the subflow has finished or joined
-  if((node->_nstate & NSTATE::RETAIN_SUBFLOW) == 0) {
-    g.clear();
-  }
+    // the subflow has finished or joined
+    if((node->_nstate & NSTATE::RETAIN_SUBFLOW) == 0) {
+        g.clear();
+    }
 
-  return false;
+    return false;
 }
 
 // Procedure: _invoke_condition_task
 inline void Executor::_invoke_condition_task(
-  Worker& worker, Node* node, SmallVector<int>& conds
-) {
-  _observer_prologue(worker, node);
-  TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-    auto& work = std::get_if<Node::Condition>(&node->_handle)->work;
-    conds = { work() };
-  });
-  _observer_epilogue(worker, node);
+    Worker& worker, Node* node, SmallVector<int>& conds
+    ) {
+    _observer_prologue(worker, node);
+    TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+        auto& work = std::get_if<Node::Condition>(&node->_handle)->work;
+        conds = { work() };
+    });
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_multi_condition_task
 inline void Executor::_invoke_multi_condition_task(
-  Worker& worker, Node* node, SmallVector<int>& conds
-) {
-  _observer_prologue(worker, node);
-  TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-    conds = std::get_if<Node::MultiCondition>(&node->_handle)->work();
-  });
-  _observer_epilogue(worker, node);
+    Worker& worker, Node* node, SmallVector<int>& conds
+    ) {
+    _observer_prologue(worker, node);
+    TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+        conds = std::get_if<Node::MultiCondition>(&node->_handle)->work();
+    });
+    _observer_epilogue(worker, node);
 }
 
 // Procedure: _invoke_module_task
 inline bool Executor::_invoke_module_task(Worker& w, Node* node) {
-  return _invoke_module_task_impl(w, node, std::get_if<Node::Module>(&node->_handle)->graph);  
+    return _invoke_module_task_impl(w, node, std::get_if<Node::Module>(&node->_handle)->graph);
 }
 
 // Procedure: _invoke_module_task_impl
 inline bool Executor::_invoke_module_task_impl(Worker& w, Node* node, Graph& graph) {
 
-  // No need to do anything for empty graph
-  if(graph.empty()) {
+    // No need to do anything for empty graph
+    if(graph.empty()) {
+        return false;
+    }
+
+    // first entry - not spawned yet
+    if((node->_nstate & NSTATE::PREEMPTED) == 0) {
+        // signal the executor to preempt this node
+        node->_nstate |= NSTATE::PREEMPTED;
+        _schedule_graph_with_parent(w, graph.begin(), graph.end(), node);
+        return true;
+    }
+
+    // second entry - already spawned
+    node->_nstate &= ~NSTATE::PREEMPTED;
+
     return false;
-  }
-
-  // first entry - not spawned yet
-  if((node->_nstate & NSTATE::PREEMPTED) == 0) {
-    // signal the executor to preempt this node
-    node->_nstate |= NSTATE::PREEMPTED;
-    _schedule_graph_with_parent(w, graph.begin(), graph.end(), node);
-    return true;
-  }
-
-  // second entry - already spawned
-  node->_nstate &= ~NSTATE::PREEMPTED;
-
-  return false;
 }
 
 
 // Procedure: _invoke_async_task
 inline bool Executor::_invoke_async_task(Worker& worker, Node* node) {
-  auto& work = std::get_if<Node::Async>(&node->_handle)->work;
-  switch(work.index()) {
+    auto& work = std::get_if<Node::Async>(&node->_handle)->work;
+    switch(work.index()) {
     // void()
     case 0:
-      _observer_prologue(worker, node);
-      TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-        std::get_if<0>(&work)->operator()();
-      });
-      _observer_epilogue(worker, node);
-    break;
-    
+        _observer_prologue(worker, node);
+        TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+            std::get_if<0>(&work)->operator()();
+        });
+        _observer_epilogue(worker, node);
+        break;
+
     // void(Runtime&)
     case 1:
-      if(_invoke_runtime_task_impl(worker, node, *std::get_if<1>(&work))) {
-        return true;
-      }
-    break;
-    
+        if(_invoke_runtime_task_impl(worker, node, *std::get_if<1>(&work))) {
+            return true;
+        }
+        break;
+
     // void(Runtime&, bool)
     case 2:
-      if(_invoke_runtime_task_impl(worker, node, *std::get_if<2>(&work))) {
-        return true;
-      }
-    break;
-  }
+        if(_invoke_runtime_task_impl(worker, node, *std::get_if<2>(&work))) {
+            return true;
+        }
+        break;
+    }
 
-  return false;
+    return false;
 }
 
 // Procedure: _invoke_dependent_async_task
 inline bool Executor::_invoke_dependent_async_task(Worker& worker, Node* node) {
-  auto& work = std::get_if<Node::DependentAsync>(&node->_handle)->work;
-  switch(work.index()) {
+    auto& work = std::get_if<Node::DependentAsync>(&node->_handle)->work;
+    switch(work.index()) {
     // void()
     case 0:
-      _observer_prologue(worker, node);
-      TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-        std::get_if<0>(&work)->operator()();
-      });
-      _observer_epilogue(worker, node);
-    break;
-    
+        _observer_prologue(worker, node);
+        TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+            std::get_if<0>(&work)->operator()();
+        });
+        _observer_epilogue(worker, node);
+        break;
+
     // void(Runtime&) - silent async
     case 1:
-      if(_invoke_runtime_task_impl(worker, node, *std::get_if<1>(&work))) {
-        return true;
-      }
-    break;
+        if(_invoke_runtime_task_impl(worker, node, *std::get_if<1>(&work))) {
+            return true;
+        }
+        break;
 
-    // void(Runtime&, bool) - async
+        // void(Runtime&, bool) - async
     case 2:
-      if(_invoke_runtime_task_impl(worker, node, *std::get_if<2>(&work))) {
-        return true;
-      }
-    break;
-  }
-  return false;
+        if(_invoke_runtime_task_impl(worker, node, *std::get_if<2>(&work))) {
+            return true;
+        }
+        break;
+    }
+    return false;
 }
 
 // Function: run
 inline tf::Future<void> Executor::run(Taskflow& f) {
-  return run_n(f, 1, [](){});
+    return run_n(f, 1, [](){});
 }
 
 // Function: run
 inline tf::Future<void> Executor::run(Taskflow&& f) {
-  return run_n(std::move(f), 1, [](){});
+    return run_n(std::move(f), 1, [](){});
 }
 
 // Function: run
 template <typename C>
 tf::Future<void> Executor::run(Taskflow& f, C&& c) {
-  return run_n(f, 1, std::forward<C>(c));
+    return run_n(f, 1, std::forward<C>(c));
 }
 
 // Function: run
 template <typename C>
 tf::Future<void> Executor::run(Taskflow&& f, C&& c) {
-  return run_n(std::move(f), 1, std::forward<C>(c));
+    return run_n(std::move(f), 1, std::forward<C>(c));
 }
 
 // Function: run_n
 inline tf::Future<void> Executor::run_n(Taskflow& f, size_t repeat) {
-  return run_n(f, repeat, [](){});
+    return run_n(f, repeat, [](){});
 }
 
 // Function: run_n
 inline tf::Future<void> Executor::run_n(Taskflow&& f, size_t repeat) {
-  return run_n(std::move(f), repeat, [](){});
+    return run_n(std::move(f), repeat, [](){});
 }
 
 // Function: run_n
 template <typename C>
 tf::Future<void> Executor::run_n(Taskflow& f, size_t repeat, C&& c) {
-  return run_until(
-    f, [repeat]() mutable { return repeat-- == 0; }, std::forward<C>(c)
-  );
+    return run_until(
+        f, [repeat]() mutable { return repeat-- == 0; }, std::forward<C>(c)
+        );
 }
 
 // Function: run_n
 template <typename C>
 tf::Future<void> Executor::run_n(Taskflow&& f, size_t repeat, C&& c) {
-  return run_until(
-    std::move(f), [repeat]() mutable { return repeat-- == 0; }, std::forward<C>(c)
-  );
+    return run_until(
+        std::move(f), [repeat]() mutable { return repeat-- == 0; }, std::forward<C>(c)
+        );
 }
 
 // Function: run_until
 template<typename P>
 tf::Future<void> Executor::run_until(Taskflow& f, P&& pred) {
-  return run_until(f, std::forward<P>(pred), [](){});
+    return run_until(f, std::forward<P>(pred), [](){});
 }
 
 // Function: run_until
 template<typename P>
 tf::Future<void> Executor::run_until(Taskflow&& f, P&& pred) {
-  return run_until(std::move(f), std::forward<P>(pred), [](){});
+    return run_until(std::move(f), std::forward<P>(pred), [](){});
 }
 
 // Function: run_until
 template <typename P, typename C>
 tf::Future<void> Executor::run_until(Taskflow& f, P&& p, C&& c) {
 
-  _increment_topology();
+    _increment_topology();
 
-  //// Need to check the empty under the lock since subflow task may
-  //// define detached blocks that modify the taskflow at the same time
-  //bool empty;
-  //{
-  //  std::lock_guard<std::mutex> lock(f._mutex);
-  //  empty = f.empty();
-  //}
+    //// Need to check the empty under the lock since subflow task may
+    //// define detached blocks that modify the taskflow at the same time
+    //bool empty;
+    //{
+    //  std::lock_guard<std::mutex> lock(f._mutex);
+    //  empty = f.empty();
+    //}
 
-  // No need to create a real topology but returns an dummy future
-  if(f.empty() || p()) {
-    c();
-    std::promise<void> promise;
-    promise.set_value();
-    _decrement_topology();
-    return tf::Future<void>(promise.get_future());
-  }
-
-  // create a topology for this run
-  auto t = std::make_shared<Topology>(f, std::forward<P>(p), std::forward<C>(c));
-
-  // need to create future before the topology got torn down quickly
-  tf::Future<void> future(t->_promise.get_future(), t);
-
-  // modifying topology needs to be protected under the lock
-  {
-    std::lock_guard<std::mutex> lock(f._mutex);
-    f._topologies.push(t);
-    if(f._topologies.size() == 1) {
-      _set_up_topology(pt::this_worker, t.get());
+    // No need to create a real topology but returns an dummy future
+    if(f.empty() || p()) {
+        c();
+        std::promise<void> promise;
+        promise.set_value();
+        _decrement_topology();
+        return tf::Future<void>(promise.get_future());
     }
-  }
 
-  return future;
+    // create a topology for this run
+    auto t = std::make_shared<Topology>(f, std::forward<P>(p), std::forward<C>(c));
+
+    // need to create future before the topology got torn down quickly
+    tf::Future<void> future(t->_promise.get_future(), t);
+
+    // modifying topology needs to be protected under the lock
+    {
+        std::lock_guard<std::mutex> lock(f._mutex);
+        f._topologies.push(t);
+        if(f._topologies.size() == 1) {
+            _set_up_topology(pt::this_worker, t.get());
+        }
+    }
+
+    return future;
 }
 
 // Function: run_until
 template <typename P, typename C>
 tf::Future<void> Executor::run_until(Taskflow&& f, P&& pred, C&& c) {
 
-  std::list<Taskflow>::iterator itr;
+    std::list<Taskflow>::iterator itr;
 
-  {
-    std::scoped_lock<std::mutex> lock(_taskflows_mutex);
-    itr = _taskflows.emplace(_taskflows.end(), std::move(f));
-    itr->_satellite = itr;
-  }
+    {
+        std::scoped_lock<std::mutex> lock(_taskflows_mutex);
+        itr = _taskflows.emplace(_taskflows.end(), std::move(f));
+        itr->_satellite = itr;
+    }
 
-  return run_until(*itr, std::forward<P>(pred), std::forward<C>(c));
+    return run_until(*itr, std::forward<P>(pred), std::forward<C>(c));
 }
 
 // Function: corun
 template <typename T>
 void Executor::corun(T& target) {
 
-  static_assert(has_graph_v<T>, "target must define a member function 'Graph& graph()'");
-  
-  if(pt::this_worker == nullptr || pt::this_worker->_executor != this) {
-    TF_THROW("corun must be called by a worker of the executor");
-  }
+    static_assert(has_graph_v<T>, "target must define a member function 'Graph& graph()'");
 
-  Node anchor;
-  _corun_graph(*pt::this_worker, &anchor, target.graph().begin(), target.graph().end());
+    if(pt::this_worker == nullptr || pt::this_worker->_executor != this) {
+        TF_THROW("corun must be called by a worker of the executor");
+    }
+
+    Node anchor;
+    _corun_graph(*pt::this_worker, &anchor, target.graph().begin(), target.graph().end());
 }
 
 // Function: corun_until
 template <typename P>
 void Executor::corun_until(P&& predicate) {
-  
-  if(pt::this_worker == nullptr || pt::this_worker->_executor != this) {
-    TF_THROW("corun_until must be called by a worker of the executor");
-  }
 
-  _corun_until(*pt::this_worker, std::forward<P>(predicate));
+    if(pt::this_worker == nullptr || pt::this_worker->_executor != this) {
+        TF_THROW("corun_until must be called by a worker of the executor");
+    }
+
+    _corun_until(*pt::this_worker, std::forward<P>(predicate));
 }
 
 // Procedure: _corun_graph
 template <typename I>
 void Executor::_corun_graph(Worker& w, Node* p, I first, I last) {
 
-  // empty graph
-  if(first == last) {
-    return;
-  }
-  
-  // anchor this parent as the blocking point
-  {
-    AnchorGuard anchor(p);
-    _schedule_graph_with_parent(w, first, last, p);
-    _corun_until(w, [p] () -> bool { 
-      return p->_join_counter.load(std::memory_order_acquire) == 0; }
-    );
-  }
+    // empty graph
+    if(first == last) {
+        return;
+    }
 
-  // rethrow the exception to the blocker
-  p->_rethrow_exception();
+    // anchor this parent as the blocking point
+    {
+        AnchorGuard anchor(p);
+        _schedule_graph_with_parent(w, first, last, p);
+        _corun_until(w, [p] () -> bool {
+            return p->_join_counter.load(std::memory_order_acquire) == 0; }
+                     );
+    }
+
+    // rethrow the exception to the blocker
+    p->_rethrow_exception();
 }
 
 // Procedure: _increment_topology
 inline void Executor::_increment_topology() {
 #if __cplusplus >= TF_CPP20
-  _num_topologies.fetch_add(1, std::memory_order_relaxed);
+    _num_topologies.fetch_add(1, std::memory_order_relaxed);
 #else
-  std::lock_guard<std::mutex> lock(_topology_mutex);
-  ++_num_topologies;
+    std::lock_guard<std::mutex> lock(_topology_mutex);
+    ++_num_topologies;
 #endif
 }
 
 // Procedure: _decrement_topology
 inline void Executor::_decrement_topology() {
 #if __cplusplus >= TF_CPP20
-  if(_num_topologies.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-    _num_topologies.notify_all();
-  }
+    if(_num_topologies.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        _num_topologies.notify_all();
+    }
 #else
-  std::lock_guard<std::mutex> lock(_topology_mutex);
-  if(--_num_topologies == 0) {
-    _topology_cv.notify_all();
-  }
+    std::lock_guard<std::mutex> lock(_topology_mutex);
+    if(--_num_topologies == 0) {
+        _topology_cv.notify_all();
+    }
 #endif
 }
 
 // Procedure: wait_for_all
 inline void Executor::wait_for_all() {
 #if __cplusplus >= TF_CPP20
-  size_t n = _num_topologies.load(std::memory_order_acquire);
-  while(n != 0) {
-    _num_topologies.wait(n, std::memory_order_acquire);
-    n = _num_topologies.load(std::memory_order_acquire);
-  }
+    size_t n = _num_topologies.load(std::memory_order_acquire);
+    while(n != 0) {
+        _num_topologies.wait(n, std::memory_order_acquire);
+        n = _num_topologies.load(std::memory_order_acquire);
+    }
 #else
-  std::unique_lock<std::mutex> lock(_topology_mutex);
-  _topology_cv.wait(lock, [&](){ return _num_topologies == 0; });
+    std::unique_lock<std::mutex> lock(_topology_mutex);
+    _topology_cv.wait(lock, [&](){ return _num_topologies == 0; });
 #endif
 }
 
 // Function: _set_up_topology
 inline void Executor::_set_up_topology(Worker* w, Topology* tpg) {
 
-  // ---- under taskflow lock ----
-  auto& g = tpg->_taskflow._graph;
-  
-  auto send = _set_up_graph(g.begin(), g.end(), tpg, nullptr);
-  tpg->_join_counter.store(send - g.begin(), std::memory_order_relaxed);
+    // ---- under taskflow lock ----
+    auto& g = tpg->_taskflow._graph;
 
-  w ? _schedule(*w, g.begin(), send) : _schedule(g.begin(), send);
+    auto send = _set_up_graph(g.begin(), g.end(), tpg, nullptr);
+    tpg->_join_counter.store(send - g.begin(), std::memory_order_relaxed);
+
+    w ? _schedule(*w, g.begin(), send) : _schedule(g.begin(), send);
 }
 
 // Function: _set_up_graph
 template <typename I>
 I Executor::_set_up_graph(I first, I last, Topology* tpg, Node* parent) {
 
-  auto send = first;
-  for(; first != last; ++first) {
+    auto send = first;
+    for(; first != last; ++first) {
 
-    auto node = first->get();
-    node->_topology = tpg;
-    node->_parent = parent;
-    node->_nstate = NSTATE::NONE;
-    node->_estate.store(ESTATE::NONE, std::memory_order_relaxed);
-    node->_set_up_join_counter();
-    node->_exception_ptr = nullptr;
+        auto node = first->get();
+        node->_topology = tpg;
+        node->_parent = parent;
+        node->_nstate = NSTATE::NONE;
+        node->_estate.store(ESTATE::NONE, std::memory_order_relaxed);
+        node->_set_up_join_counter();
+        node->_exception_ptr = nullptr;
 
-    // move source to the first partition
-    // root, root, root, v1, v2, v3, v4, ...
-    if(node->num_predecessors() == 0) {
-      std::iter_swap(send++, first);
+        // move source to the first partition
+        // root, root, root, v1, v2, v3, v4, ...
+        if(node->num_predecessors() == 0) {
+            std::iter_swap(send++, first);
+        }
     }
-  }
-  return send;
+    return send;
 }
 
 // Function: _tear_down_topology
 inline void Executor::_tear_down_topology(Worker& worker, Topology* tpg) {
 
-  auto &f = tpg->_taskflow;
+    auto &f = tpg->_taskflow;
 
-  //assert(&tpg == &(f._topologies.front()));
+    //assert(&tpg == &(f._topologies.front()));
 
-  // case 1: we still need to run the topology again
-  if(!tpg->_exception_ptr && !tpg->cancelled() && !tpg->_pred()) {
-    //assert(tpg->_join_counter == 0);
-    std::lock_guard<std::mutex> lock(f._mutex);
-    _set_up_topology(&worker, tpg);
-  }
-  // case 2: the final run of this topology
-  else {
-
-    // invoke the callback after each run
-    if(tpg->_call != nullptr) {
-      tpg->_call();
+    // case 1: we still need to run the topology again
+    if(!tpg->_exception_ptr && !tpg->cancelled() && !tpg->_pred()) {
+        //assert(tpg->_join_counter == 0);
+        std::lock_guard<std::mutex> lock(f._mutex);
+        _set_up_topology(&worker, tpg);
     }
-
-    // If there is another run (interleave between lock)
-    if(std::unique_lock<std::mutex> lock(f._mutex); f._topologies.size()>1) {
-      //assert(tpg->_join_counter == 0);
-
-      // Set the promise
-      tpg->_promise.set_value();
-      f._topologies.pop();
-      tpg = f._topologies.front().get();
-
-      // decrement the topology
-      _decrement_topology();
-
-      // set up topology needs to be under the lock or it can
-      // introduce memory order error with pop
-      _set_up_topology(&worker, tpg);
-    }
+    // case 2: the final run of this topology
     else {
-      //assert(f._topologies.size() == 1);
 
-      auto fetched_tpg {std::move(f._topologies.front())};
-      f._topologies.pop();
-      auto satellite {f._satellite};
+        // invoke the callback after each run
+        if(tpg->_call != nullptr) {
+            tpg->_call();
+        }
 
-      lock.unlock();
-      
-      // Soon after we carry out the promise, there is no longer any guarantee
-      // for the lifetime of the associated taskflow.
-      fetched_tpg->_carry_out_promise();
+        // If there is another run (interleave between lock)
+        if(std::unique_lock<std::mutex> lock(f._mutex); f._topologies.size()>1) {
+            //assert(tpg->_join_counter == 0);
 
-      _decrement_topology();
+            // Set the promise
+            tpg->_promise.set_value();
+            f._topologies.pop();
+            tpg = f._topologies.front().get();
 
-      // remove the taskflow if it is managed by the executor
-      // TODO: in the future, we may need to synchronize on wait
-      // (which means the following code should the moved before set_value)
-      if(satellite) {
-        std::scoped_lock<std::mutex> satellite_lock(_taskflows_mutex);
-        _taskflows.erase(*satellite);
-      }
+            // decrement the topology
+            _decrement_topology();
+
+            // set up topology needs to be under the lock or it can
+            // introduce memory order error with pop
+            _set_up_topology(&worker, tpg);
+        }
+        else {
+            //assert(f._topologies.size() == 1);
+
+            auto fetched_tpg {std::move(f._topologies.front())};
+            f._topologies.pop();
+            auto satellite {f._satellite};
+
+            lock.unlock();
+
+            // Soon after we carry out the promise, there is no longer any guarantee
+            // for the lifetime of the associated taskflow.
+            fetched_tpg->_carry_out_promise();
+
+            _decrement_topology();
+
+            // remove the taskflow if it is managed by the executor
+            // TODO: in the future, we may need to synchronize on wait
+            // (which means the following code should the moved before set_value)
+            if(satellite) {
+                std::scoped_lock<std::mutex> satellite_lock(_taskflows_mutex);
+                _taskflows.erase(*satellite);
+            }
+        }
     }
-  }
 }
 
 // ############################################################################
@@ -2307,14 +2307,14 @@ inline void Executor::_tear_down_topology(Worker& worker, Topology* tpg) {
 
 inline void Subflow::join() {
 
-  if(!joinable()) {
-    TF_THROW("subflow already joined");
-  }
-    
-  _executor._corun_graph(_worker, _parent, _graph.begin(), _graph.end());
-  
-  // join here since corun graph may throw exception
-  _parent->_nstate |= NSTATE::JOINED_SUBFLOW;
+    if(!joinable()) {
+        TF_THROW("subflow already joined");
+    }
+
+    _executor._corun_graph(_worker, _parent, _graph.begin(), _graph.end());
+
+    // join here since corun graph may throw exception
+    _parent->_nstate |= NSTATE::JOINED_SUBFLOW;
 }
 
 #endif

--- a/taskflow/core/flow_builder.hpp
+++ b/taskflow/core/flow_builder.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "task.hpp"
 #include "../algorithm/partitioner.hpp"
@@ -21,16 +21,71 @@ from which tf::Taskflow and tf::Subflow are derived.
 */
 class FlowBuilder {
 
-  friend class Executor;
+    friend class Executor;
 
-  public:
+public:
 
-  /**
+    /**
   @brief constructs a flow builder with a graph
   */
-  FlowBuilder(Graph& graph);
+    FlowBuilder(Graph& graph);
+#ifdef TF_ENABLE_DELEGATE
+    template <auto C>
+        requires is_static_task_v<decltype(C)>
+    Task emplace();
+    template <auto C, typename T>
+        requires is_static_task_with_arg_v<decltype(C), T>
+    Task emplace(T&& value_or_value_or_instance);
 
-  /**
+
+    // Runtime without value_or_instance
+    template <auto C>
+        requires is_runtime_task_v<decltype(C)>
+    Task emplace();
+    // Runtime with value_or_instance
+    template <auto C, typename T>
+        requires is_runtime_task_with_arg_v<decltype(C), T>
+    Task emplace(T&& value_or_instance);
+
+    // Subflow without value_or_instance
+    template <auto C>
+        requires is_subflow_task_v<decltype(C)>
+    Task emplace();
+    // Subflow with value_or_instance
+    template <auto C, typename T>
+        requires is_subflow_task_with_arg_v<decltype(C), T>
+    Task emplace(T&& value_or_instance);
+
+    // Condition without value_or_instance
+    template <auto C>
+        requires is_condition_task_v<decltype(C)>
+    Task emplace();
+    // Condition with value_or_instance
+    template <auto C, typename T>
+        requires is_condition_task_with_arg_v<decltype(C), T>
+    Task emplace(T&& value_or_instance);
+
+    // Multi-condition without value_or_instance
+    template <auto C>
+        requires is_multi_condition_task_v<decltype(C)>
+    Task emplace();
+    // Multi-condition with value_or_instance
+    template <auto C, typename T>
+        requires is_multi_condition_task_with_arg_v<decltype(C), T>
+    Task emplace(T&& value_or_instance);
+
+
+    template <auto... C>
+        requires (sizeof...(C) > 1)
+    auto emplace();
+
+    template <auto... C, typename... T>
+        requires (sizeof...(C) > 1 && sizeof...(C) == sizeof...(T))
+    auto emplace(T&&... ts);
+
+
+#else
+    /**
   @brief creates a static task
 
   @tparam C callable type constructible from std::function<void()>
@@ -44,16 +99,16 @@ class FlowBuilder {
   @code{.cpp}
   tf::Task static_task = taskflow.emplace([](){});
   @endcode
-  
+
   @note
   Please refer to @ref StaticTasking for details.
   */
-  template <typename C,
-    std::enable_if_t<is_static_task_v<C>, void>* = nullptr
-  >
-  Task emplace(C&& callable);
-  
-  /**
+    template <typename C,
+             std::enable_if_t<is_static_task_v<C>, void>* = nullptr
+             >
+    Task emplace(C&& callable);
+
+    /**
   @brief creates a runtime task
 
   @tparam C callable type constructible from std::function<void(tf::Runtime&)>
@@ -71,12 +126,12 @@ class FlowBuilder {
   @note
   Please refer to @ref RuntimeTasking for details.
   */
-  template <typename C,
-    std::enable_if_t<is_runtime_task_v<C>, void>* = nullptr
-  >
-  Task emplace(C&& callable);
+    template <typename C,
+             std::enable_if_t<is_runtime_task_v<C>, void>* = nullptr
+             >
+    Task emplace(C&& callable);
 
-  /**
+    /**
   @brief creates a dynamic task
 
   @tparam C callable type constructible from std::function<void(tf::Subflow&)>
@@ -98,12 +153,12 @@ class FlowBuilder {
   @note
   Please refer to @ref SubflowTasking for details.
   */
-  template <typename C,
-    std::enable_if_t<is_subflow_task_v<C>, void>* = nullptr
-  >
-  Task emplace(C&& callable);
+    template <typename C,
+             std::enable_if_t<is_subflow_task_v<C>, void>* = nullptr
+             >
+    Task emplace(C&& callable);
 
-  /**
+    /**
   @brief creates a condition task
 
   @tparam C callable type constructible from std::function<int()>
@@ -133,12 +188,12 @@ class FlowBuilder {
   @note
   Please refer to @ref ConditionalTasking for details.
   */
-  template <typename C,
-    std::enable_if_t<is_condition_task_v<C>, void>* = nullptr
-  >
-  Task emplace(C&& callable);
+    template <typename C,
+             std::enable_if_t<is_condition_task_v<C>, void>* = nullptr
+             >
+    Task emplace(C&& callable);
 
-  /**
+    /**
   @brief creates a multi-condition task
 
   @tparam C callable type constructible from
@@ -170,12 +225,12 @@ class FlowBuilder {
   @note
   Please refer to @ref ConditionalTasking for details.
   */
-  template <typename C,
-    std::enable_if_t<is_multi_condition_task_v<C>, void>* = nullptr
-  >
-  Task emplace(C&& callable);
+    template <typename C,
+             std::enable_if_t<is_multi_condition_task_v<C>, void>* = nullptr
+             >
+    Task emplace(C&& callable);
 
-  /**
+    /**
   @brief creates multiple tasks from a list of callable objects
 
   @tparam C callable types
@@ -199,10 +254,10 @@ class FlowBuilder {
   );
   @endcode
   */
-  template <typename... C, std::enable_if_t<(sizeof...(C)>1), void>* = nullptr>
-  auto emplace(C&&... callables);
-
-  /**
+    template <typename... C, std::enable_if_t<(sizeof...(C)>1), void>* = nullptr>
+    auto emplace(C&&... callables);
+#endif
+    /**
   @brief removes a task from a taskflow
 
   @param task task to remove
@@ -222,9 +277,9 @@ class FlowBuilder {
   taskflow.erase(A);
   @endcode
   */
-  void erase(Task task);
+    void erase(Task task);
 
-  /**
+    /**
   @brief creates a module task for the target object
 
   @tparam T target object type
@@ -276,10 +331,10 @@ class FlowBuilder {
   @note
   Please refer to @ref ComposableTasking for details.
   */
-  template <typename T>
-  Task composed_of(T& object);
+    template <typename T>
+    Task composed_of(T& object);
 
-  /**
+    /**
   @brief creates a placeholder task
 
   @return a tf::Task handle
@@ -303,9 +358,9 @@ class FlowBuilder {
   assert(task.empty() == false && task.has_work() == false);
   @endcode
   */
-  Task placeholder();
+    Task placeholder();
 
-  /**
+    /**
   @brief adds adjacent dependency links to a linear list of tasks
 
   @param tasks a vector of tasks
@@ -322,9 +377,9 @@ class FlowBuilder {
   @endcode
 
   */
-  void linearize(std::vector<Task>& tasks);
+    void linearize(std::vector<Task>& tasks);
 
-  /**
+    /**
   @brief adds adjacent dependency links to a linear list of tasks
 
   @param tasks an initializer list of tasks
@@ -339,14 +394,14 @@ class FlowBuilder {
   taskflow.linearize({A, B, C, D});  // A->B->C->D
   @endcode
   */
-  void linearize(std::initializer_list<Task> tasks);
+    void linearize(std::initializer_list<Task> tasks);
 
 
-  // ------------------------------------------------------------------------
-  // parallel iterations
-  // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // parallel iterations
+    // ------------------------------------------------------------------------
 
-  /**
+    /**
   @brief constructs an STL-styled parallel-for task
 
   @tparam B beginning iterator type
@@ -378,11 +433,11 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelIterations for details.
   */
-  template <typename B, typename E, typename C, typename P = DefaultPartitioner>
-  Task for_each(B first, E last, C callable, P part = P());
-  
-  /**
-  @brief constructs an index-based parallel-for task 
+    template <typename B, typename E, typename C, typename P = DefaultPartitioner>
+    Task for_each(B first, E last, C callable, P part = P());
+
+    /**
+  @brief constructs an index-based parallel-for task
 
   @tparam B beginning index type (must be integral)
   @tparam E ending index type (must be integral)
@@ -420,29 +475,29 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelIterations for details.
   */
-  template <typename B, typename E, typename S, typename C, typename P = DefaultPartitioner>
-  Task for_each_index(B first, E last, S step, C callable, P part = P());
+    template <typename B, typename E, typename S, typename C, typename P = DefaultPartitioner>
+    Task for_each_index(B first, E last, S step, C callable, P part = P());
 
-  /**
+    /**
   @brief constructs an index range-based parallel-for task
 
   @tparam R index range type (tf::IndexRange)
   @tparam C callable type
   @tparam P partitioner type (default tf::DefaultPartitioner)
 
-  @param range index range 
+  @param range index range
   @param callable callable object to apply to each valid index
   @param part partitioning algorithm to schedule parallel iterations
 
   @return a tf::Task handle
 
-  The task spawns asynchronous tasks that applies the callable object to 
+  The task spawns asynchronous tasks that applies the callable object to
   in the range <tt>[first, last)</tt> with the step size.
 
   @code{.cpp}
   // [0, 17) with a step size of 2 using tf::IndexRange
   tf::IndexRange<int> range(0, 17, 2);
-  
+
   // parallelize the sequence [0, 2, 4, 6, 8, 10, 12, 14, 16]
   taskflow.for_each_by_index(range, [](tf::IndexRange<int> range) {
     // iterate each index in the subrange
@@ -450,7 +505,7 @@ class FlowBuilder {
       printf("iterate %d\n", i);
     }
   });
-  
+
   executor.run(taskflow).wait();
   @endcode
 
@@ -459,14 +514,14 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelIterations for details.
   */
-  template <typename R, typename C, typename P = DefaultPartitioner>
-  Task for_each_by_index(R range, C callable, P part = P());
+    template <typename R, typename C, typename P = DefaultPartitioner>
+    Task for_each_by_index(R range, C callable, P part = P());
 
-  // ------------------------------------------------------------------------
-  // transform
-  // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // transform
+    // ------------------------------------------------------------------------
 
-  /**
+    /**
   @brief constructs a parallel-transform task
 
   @tparam B beginning input iterator type
@@ -496,17 +551,17 @@ class FlowBuilder {
   Iterators can be made stateful by using std::reference_wrapper
   The callable needs to take a single argument of the dereferenced
   iterator type.
-  
+
   @note
   Please refer to @ref ParallelTransforms for details.
   */
-  template <
-    typename B, typename E, typename O, typename C, typename P = DefaultPartitioner,
-    std::enable_if_t<is_partitioner_v<std::decay_t<P>>, void>* = nullptr
-  >
-  Task transform(B first1, E last1, O d_first, C c, P part = P());
-  
-  /**
+    template <
+        typename B, typename E, typename O, typename C, typename P = DefaultPartitioner,
+        std::enable_if_t<is_partitioner_v<std::decay_t<P>>, void>* = nullptr
+        >
+    Task transform(B first1, E last1, O d_first, C c, P part = P());
+
+    /**
   @brief constructs a parallel-transform task
 
   @tparam B1 beginning input iterator type for the first input range
@@ -538,21 +593,21 @@ class FlowBuilder {
   Iterators can be made stateful by using std::reference_wrapper
   The callable needs to take two arguments of dereferenced elements
   from the two input ranges.
-  
+
   @note
   Please refer to @ref ParallelTransforms for details.
   */
-  template <
-    typename B1, typename E1, typename B2, typename O, typename C, typename P=DefaultPartitioner,
-    std::enable_if_t<!is_partitioner_v<std::decay_t<C>>, void>* = nullptr
-  >
-  Task transform(B1 first1, E1 last1, B2 first2, O d_first, C c, P part = P());
-  
-  // ------------------------------------------------------------------------
-  // reduction
-  // ------------------------------------------------------------------------
+    template <
+        typename B1, typename E1, typename B2, typename O, typename C, typename P=DefaultPartitioner,
+        std::enable_if_t<!is_partitioner_v<std::decay_t<C>>, void>* = nullptr
+        >
+    Task transform(B1 first1, E1 last1, B2 first2, O d_first, C c, P part = P());
 
-  /**
+    // ------------------------------------------------------------------------
+    // reduction
+    // ------------------------------------------------------------------------
+
+    /**
   @brief constructs an STL-styled parallel-reduction task
 
   @tparam B beginning iterator type
@@ -585,10 +640,10 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelReduction for details.
   */
-  template <typename B, typename E, typename T, typename O, typename P = DefaultPartitioner>
-  Task reduce(B first, E last, T& init, O bop, P part = P());
+    template <typename B, typename E, typename T, typename O, typename P = DefaultPartitioner>
+    Task reduce(B first, E last, T& init, O bop, P part = P());
 
-  /**
+    /**
   @brief constructs an index range-based parallel-reduction task
 
   @tparam R index range type (tf::IndexRange)
@@ -597,18 +652,18 @@ class FlowBuilder {
   @tparam G global reducer type
   @tparam P partitioner type (default tf::DefaultPartitioner)
 
-  @param range index range 
+  @param range index range
   @param init initial value of the reduction and the storage for the reduced result
   @param lop binary operator that will be applied locally per worker
-  @param gop binary operator that will be applied globally among worker 
+  @param gop binary operator that will be applied globally among worker
   @param part partitioning algorithm to schedule parallel iterations
 
   @return a tf::Task handle
 
   The task spawns asynchronous tasks to perform parallel reduction over a range with @c init.
   The reduced result is store in @c init.
-  Unlike the iterator-based reduction, 
-  index range-based reduction is particularly useful for applications that benefit from SIMD optimizations 
+  Unlike the iterator-based reduction,
+  index range-based reduction is particularly useful for applications that benefit from SIMD optimizations
   or other range-based processing strategies.
 
   @code{.cpp}
@@ -642,14 +697,14 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelReduction for details.
   */
-  template <typename R, typename T, typename L, typename G, typename P = DefaultPartitioner>
-  Task reduce_by_index(R range, T& init, L lop, G gop, P part = P());
-  
-  // ------------------------------------------------------------------------
-  // transform and reduction
-  // ------------------------------------------------------------------------
+    template <typename R, typename T, typename L, typename G, typename P = DefaultPartitioner>
+    Task reduce_by_index(R range, T& init, L lop, G gop, P part = P());
 
-  /**
+    // ------------------------------------------------------------------------
+    // transform and reduction
+    // ------------------------------------------------------------------------
+
+    /**
   @brief constructs an STL-styled parallel transform-reduce task
 
   @tparam B beginning iterator type
@@ -684,13 +739,13 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelReduction for details.
   */
-  template <
-    typename B, typename E, typename T, typename BOP, typename UOP, typename P = DefaultPartitioner,
-    std::enable_if_t<is_partitioner_v<std::decay_t<P>>, void>* = nullptr
-  >
-  Task transform_reduce(B first, E last, T& init, BOP bop, UOP uop, P part = P());
+    template <
+        typename B, typename E, typename T, typename BOP, typename UOP, typename P = DefaultPartitioner,
+        std::enable_if_t<is_partitioner_v<std::decay_t<P>>, void>* = nullptr
+        >
+    Task transform_reduce(B first, E last, T& init, BOP bop, UOP uop, P part = P());
 
-  /**
+    /**
   @brief constructs an STL-styled parallel transform-reduce task
   @tparam B1 first beginning iterator type
   @tparam E1 first ending iterator type
@@ -699,7 +754,7 @@ class FlowBuilder {
   @tparam BOP_R binary reducer type
   @tparam BOP_T binary transformation type
   @tparam P partitioner type (default tf::DefaultPartitioner)
- 
+
   @param first1 iterator to the beginning of the first range (inclusive)
   @param last1 iterator to the end of the first range (exclusive)
   @param first2 iterator to the beginning of the second range
@@ -707,38 +762,38 @@ class FlowBuilder {
   @param bop_r binary operator that will be applied in unspecified order to the results of @c bop_t
   @param bop_t binary operator that will be applied to transform each element in the range to the result type
   @param part partitioning algorithm to schedule parallel iterations
- 
+
   @return a tf::Task handle
- 
+
   The task spawns asynchronous tasks to perform parallel reduction over @c init and
   transformed elements in the range <tt>[first, last)</tt>.
   The reduced result is store in @c init.
   This method is equivalent to the parallel execution of the following loop:
- 
+
   @code{.cpp}
   for(auto itr1=first1, itr2=first2; itr1!=last1; itr1++, itr2++) {
     init = bop_r(init, bop_t(*itr1, *itr2));
   }
   @endcode
- 
+
   Iterators can be made stateful by using std::reference_wrapper
 
   @note
   Please refer to @ref ParallelReduction for details.
   */
-  
-  template <
-    typename B1, typename E1, typename B2, typename T, typename BOP_R, typename BOP_T, 
-    typename P = DefaultPartitioner,
-    std::enable_if_t<!is_partitioner_v<std::decay_t<BOP_T>>, void>* = nullptr
-  >
-  Task transform_reduce(
-    B1 first1, E1 last1, B2 first2, T& init, BOP_R bop_r, BOP_T bop_t, P part = P()
-  );
 
-  // ------------------------------------------------------------------------
-  // scan
-  // ------------------------------------------------------------------------
+    template <
+        typename B1, typename E1, typename B2, typename T, typename BOP_R, typename BOP_T,
+        typename P = DefaultPartitioner,
+        std::enable_if_t<!is_partitioner_v<std::decay_t<BOP_T>>, void>* = nullptr
+        >
+    Task transform_reduce(
+        B1 first1, E1 last1, B2 first2, T& init, BOP_R bop_r, BOP_T bop_t, P part = P()
+        );
+
+    // ------------------------------------------------------------------------
+    // scan
+    // ------------------------------------------------------------------------
 
     /**
   @brief creates an STL-styled parallel inclusive-scan task
@@ -778,10 +833,10 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelScan for details.
   */
-  template <typename B, typename E, typename D, typename BOP>
-  Task inclusive_scan(B first, E last, D d_first, BOP bop);
-  
-  /**
+    template <typename B, typename E, typename D, typename BOP>
+    Task inclusive_scan(B first, E last, D d_first, BOP bop);
+
+    /**
   @brief creates an STL-styled parallel inclusive-scan task with an initial value
 
   @tparam B beginning iterator type
@@ -797,11 +852,11 @@ class FlowBuilder {
   @param init initial value
 
   Performs the cumulative sum (aka prefix sum, aka scan) of the input range
-  and writes the result to the output range. 
+  and writes the result to the output range.
   Each element of the output range contains the
   running total of all earlier elements (and the initial value)
   using the given binary operator for summation.
-  
+
   This function generates an @em inclusive scan, meaning the N-th element
   of the output range is the sum of the first N input elements,
   so the N-th input element is included.
@@ -812,20 +867,20 @@ class FlowBuilder {
     input.begin(), input.end(), input.begin(), std::plus<int>{}, -1
   );
   executor.run(taskflow).wait();
-  
+
   // input is {0, 2, 5, 9, 14}
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
- 
+
   @note
   Please refer to @ref ParallelScan for details.
 
   */
-  template <typename B, typename E, typename D, typename BOP, typename T>
-  Task inclusive_scan(B first, E last, D d_first, BOP bop, T init);
-  
-  /**
+    template <typename B, typename E, typename D, typename BOP, typename T>
+    Task inclusive_scan(B first, E last, D d_first, BOP bop, T init);
+
+    /**
   @brief creates an STL-styled parallel exclusive-scan task
 
   @tparam B beginning iterator type
@@ -841,11 +896,11 @@ class FlowBuilder {
   @param bop function to perform summation
 
   Performs the cumulative sum (aka prefix sum, aka scan) of the input range
-  and writes the result to the output range. 
+  and writes the result to the output range.
   Each element of the output range contains the
   running total of all earlier elements (and the initial value)
   using the given binary operator for summation.
-  
+
   This function generates an @em exclusive scan, meaning the N-th element
   of the output range is the sum of the first N-1 input elements,
   so the N-th input element is not included.
@@ -856,23 +911,23 @@ class FlowBuilder {
     input.begin(), input.end(), input.begin(), -1, std::plus<int>{}
   );
   executor.run(taskflow).wait();
-  
+
   // input is {-1, 0, 2, 5, 9}
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
-  
+
   @note
   Please refer to @ref ParallelScan for details.
   */
-  template <typename B, typename E, typename D, typename T, typename BOP>
-  Task exclusive_scan(B first, E last, D d_first, T init, BOP bop);
-  
-  // ------------------------------------------------------------------------
-  // transform scan
-  // ------------------------------------------------------------------------
-  
-  /**
+    template <typename B, typename E, typename D, typename T, typename BOP>
+    Task exclusive_scan(B first, E last, D d_first, T init, BOP bop);
+
+    // ------------------------------------------------------------------------
+    // transform scan
+    // ------------------------------------------------------------------------
+
+    /**
   @brief creates an STL-styled parallel transform-inclusive scan task
 
   @tparam B beginning iterator type
@@ -892,7 +947,7 @@ class FlowBuilder {
   running total of all earlier elements
   using @c uop to transform the input elements
   and using @c bop for summation.
-  
+
   This function generates an @em inclusive scan, meaning the Nth element
   of the output range is the sum of the first N input elements,
   so the Nth input element is included.
@@ -900,23 +955,23 @@ class FlowBuilder {
   @code{.cpp}
   std::vector<int> input = {1, 2, 3, 4, 5};
   taskflow.transform_inclusive_scan(
-    input.begin(), input.end(), input.begin(), std::plus<int>{}, 
+    input.begin(), input.end(), input.begin(), std::plus<int>{},
     [] (int item) { return -item; }
   );
   executor.run(taskflow).wait();
-  
+
   // input is {-1, -3, -6, -10, -15}
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
-  
+
   @note
   Please refer to @ref ParallelScan for details.
   */
-  template <typename B, typename E, typename D, typename BOP, typename UOP>
-  Task transform_inclusive_scan(B first, E last, D d_first, BOP bop, UOP uop);
-  
-  /**
+    template <typename B, typename E, typename D, typename BOP, typename UOP>
+    Task transform_inclusive_scan(B first, E last, D d_first, BOP bop, UOP uop);
+
+    /**
   @brief creates an STL-styled parallel transform-inclusive scan task
 
   @tparam B beginning iterator type
@@ -938,7 +993,7 @@ class FlowBuilder {
   running total of all earlier elements (including an initial value)
   using @c uop to transform the input elements
   and using @c bop for summation.
-  
+
   This function generates an @em inclusive scan, meaning the Nth element
   of the output range is the sum of the first N input elements,
   so the Nth input element is included.
@@ -946,24 +1001,24 @@ class FlowBuilder {
   @code{.cpp}
   std::vector<int> input = {1, 2, 3, 4, 5};
   taskflow.transform_inclusive_scan(
-    input.begin(), input.end(), input.begin(), std::plus<int>{}, 
+    input.begin(), input.end(), input.begin(), std::plus<int>{},
     [] (int item) { return -item; },
     -1
   );
   executor.run(taskflow).wait();
-  
+
   // input is {-2, -4, -7, -11, -16}
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
-  
+
   @note
   Please refer to @ref ParallelScan for details.
   */
-  template <typename B, typename E, typename D, typename BOP, typename UOP, typename T>
-  Task transform_inclusive_scan(B first, E last, D d_first, BOP bop, UOP uop, T init);
-  
-  /**
+    template <typename B, typename E, typename D, typename BOP, typename UOP, typename T>
+    Task transform_inclusive_scan(B first, E last, D d_first, BOP bop, UOP uop, T init);
+
+    /**
   @brief creates an STL-styled parallel transform-exclusive scan task
 
   @tparam B beginning iterator type
@@ -985,7 +1040,7 @@ class FlowBuilder {
   running total of all earlier elements (including an initial value)
   using @c uop to transform the input elements
   and using @c bop for summation.
-  
+
   This function generates an @em exclusive scan, meaning the Nth element
   of the output range is the sum of the first N-1 input elements,
   so the Nth input element is not included.
@@ -997,23 +1052,23 @@ class FlowBuilder {
     [](int item) { return -item; }
   );
   executor.run(taskflow).wait();
-  
+
   // input is {-1, -2, -4, -7, -11}
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
-  
+
   @note
   Please refer to @ref ParallelScan for details.
   */
-  template <typename B, typename E, typename D, typename T, typename BOP, typename UOP>
-  Task transform_exclusive_scan(B first, E last, D d_first, T init, BOP bop, UOP uop);
+    template <typename B, typename E, typename D, typename T, typename BOP, typename UOP>
+    Task transform_exclusive_scan(B first, E last, D d_first, T init, BOP bop, UOP uop);
 
-  // ------------------------------------------------------------------------
-  // find
-  // ------------------------------------------------------------------------
- 
-  /**
+    // ------------------------------------------------------------------------
+    // find
+    // ------------------------------------------------------------------------
+
+    /**
   @brief constructs a task to perform STL-styled find-if algorithm
 
   @tparam B beginning iterator type
@@ -1021,14 +1076,14 @@ class FlowBuilder {
   @tparam T resulting iterator type
   @tparam UOP unary predicate type
   @tparam P partitioner type
-  
+
   @param first start of the input range
   @param last end of the input range
   @param result resulting iterator to the found element in the input range
   @param predicate unary predicate which returns @c true for the required element
   @param part partitioning algorithm (default tf::DefaultPartitioner)
 
-  Returns an iterator to the first element in the range <tt>[first, last)</tt> 
+  Returns an iterator to the first element in the range <tt>[first, last)</tt>
   that satisfies the given criteria (or last if there is no such iterator).
   This method is equivalent to the parallel execution of the following loop:
 
@@ -1043,7 +1098,7 @@ class FlowBuilder {
   }
   @endcode
 
-  For example, the code below find the element that satisfies the given 
+  For example, the code below find the element that satisfies the given
   criteria (value plus one is equal to 23) from an input range of 10 elements:
 
   @code{.cpp}
@@ -1055,13 +1110,13 @@ class FlowBuilder {
   executor.run(taskflow).wait();
   assert(*result == 22);
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
   */
-  template <typename B, typename E, typename T, typename UOP, typename P = DefaultPartitioner>
-  Task find_if(B first, E last, T &result, UOP predicate, P part = P());
+    template <typename B, typename E, typename T, typename UOP, typename P = DefaultPartitioner>
+    Task find_if(B first, E last, T &result, UOP predicate, P part = P());
 
-  /**
+    /**
   @brief constructs a task to perform STL-styled find-if-not algorithm
 
   @tparam B beginning iterator type
@@ -1069,14 +1124,14 @@ class FlowBuilder {
   @tparam T resulting iterator type
   @tparam UOP unary predicate type
   @tparam P partitioner type
-  
+
   @param first start of the input range
   @param last end of the input range
   @param result resulting iterator to the found element in the input range
   @param predicate unary predicate which returns @c false for the required element
   @param part partitioning algorithm (default tf::DefaultPartitioner)
 
-  Returns an iterator to the first element in the range <tt>[first, last)</tt> 
+  Returns an iterator to the first element in the range <tt>[first, last)</tt>
   that satisfies the given criteria (or last if there is no such iterator).
   This method is equivalent to the parallel execution of the following loop:
 
@@ -1091,7 +1146,7 @@ class FlowBuilder {
   }
   @endcode
 
-  For example, the code below find the element that satisfies the given 
+  For example, the code below find the element that satisfies the given
   criteria (value is not equal to 1) from an input range of 10 elements:
 
   @code{.cpp}
@@ -1103,13 +1158,13 @@ class FlowBuilder {
   executor.run(taskflow).wait();
   assert(*result == 22);
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
   */
-  template <typename B, typename E, typename T, typename UOP, typename P = DefaultPartitioner>
-  Task find_if_not(B first, E last, T &result, UOP predicate, P part = P());
+    template <typename B, typename E, typename T, typename UOP, typename P = DefaultPartitioner>
+    Task find_if_not(B first, E last, T &result, UOP predicate, P part = P());
 
-  /**
+    /**
   @brief constructs a task to perform STL-styled min-element algorithm
 
   @tparam B beginning iterator type
@@ -1117,14 +1172,14 @@ class FlowBuilder {
   @tparam T resulting iterator type
   @tparam C comparator type
   @tparam P partitioner type
-  
+
   @param first start of the input range
   @param last end of the input range
   @param result resulting iterator to the found element in the input range
   @param comp comparison function object
   @param part partitioning algorithm (default tf::DefaultPartitioner)
 
-  Finds the smallest element in the <tt>[first, last)</tt> 
+  Finds the smallest element in the <tt>[first, last)</tt>
   using the given comparison function object.
   The iterator to that smallest element is stored in @c result.
   This method is equivalent to the parallel execution of the following loop:
@@ -1155,13 +1210,13 @@ class FlowBuilder {
   executor.run(taskflow).wait();
   assert(*result == -1);
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
   */
-  template <typename B, typename E, typename T, typename C, typename P>
-  Task min_element(B first, E last, T& result, C comp, P part);
-  
-  /**
+    template <typename B, typename E, typename T, typename C, typename P>
+    Task min_element(B first, E last, T& result, C comp, P part);
+
+    /**
   @brief constructs a task to perform STL-styled max-element algorithm
 
   @tparam B beginning iterator type
@@ -1169,14 +1224,14 @@ class FlowBuilder {
   @tparam T resulting iterator type
   @tparam C comparator type
   @tparam P partitioner type
-  
+
   @param first start of the input range
   @param last end of the input range
   @param result resulting iterator to the found element in the input range
   @param comp comparison function object
   @param part partitioning algorithm (default tf::DefaultPartitioner)
 
-  Finds the largest element in the <tt>[first, last)</tt> 
+  Finds the largest element in the <tt>[first, last)</tt>
   using the given comparison function object.
   The iterator to that largest element is stored in @c result.
   This method is equivalent to the parallel execution of the following loop:
@@ -1207,17 +1262,17 @@ class FlowBuilder {
   executor.run(taskflow).wait();
   assert(*result == 2);
   @endcode
-  
+
   Iterators can be made stateful by using std::reference_wrapper
   */
-  template <typename B, typename E, typename T, typename C, typename P>
-  Task max_element(B first, E last, T& result, C comp, P part);
+    template <typename B, typename E, typename T, typename C, typename P>
+    Task max_element(B first, E last, T& result, C comp, P part);
 
-  // ------------------------------------------------------------------------
-  // sort
-  // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // sort
+    // ------------------------------------------------------------------------
 
-  /**
+    /**
   @brief constructs a dynamic task to perform STL-styled parallel sort
 
   @tparam B beginning iterator type (random-accessible)
@@ -1236,10 +1291,10 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelSort for details.
   */
-  template <typename B, typename E, typename C>
-  Task sort(B first, E last, C cmp);
+    template <typename B, typename E, typename C>
+    Task sort(B first, E last, C cmp);
 
-  /**
+    /**
   @brief constructs a dynamic task to perform STL-styled parallel sort using
          the @c std::less<T> comparator, where @c T is the element type
 
@@ -1258,108 +1313,231 @@ class FlowBuilder {
   @note
   Please refer to @ref ParallelSort for details.
    */
-  template <typename B, typename E>
-  Task sort(B first, E last);
+    template <typename B, typename E>
+    Task sort(B first, E last);
 
-  protected:
+protected:
 
-  /**
+    /**
   @brief associated graph object
   */
-  Graph& _graph;
+    Graph& _graph;
 
-  private:
+private:
 
-  template <typename L>
-  void _linearize(L&);
+    template <typename L>
+    void _linearize(L&);
 };
 
 // Constructor
 inline FlowBuilder::FlowBuilder(Graph& graph) :
-  _graph {graph} {
+    _graph {graph} {
 }
 
+#ifdef TF_ENABLE_DELEGATE
+// Static without value_or_instance
+template <auto C>
+    requires is_static_task_v<decltype(C)>
+Task FlowBuilder::emplace() {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Static{WorkHandle<void()>{connect_arg<C>}}
+        )};
+}
+
+// Static with value_or_instance
+template <auto C, typename T>
+    requires is_static_task_with_arg_v<decltype(C), T>
+Task FlowBuilder::emplace(T&& value_or_instance) {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Static{WorkHandle<void()>{connect_arg<C>, std::forward<T>(value_or_instance)}}
+        )};
+}
+
+// Runtime without value_or_instance
+template <auto C>
+    requires is_runtime_task_v<decltype(C)>
+Task FlowBuilder::emplace() {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Runtime{WorkHandle<void(tf::Runtime&)>{connect_arg<C>}}
+        )};
+}
+
+// Runtime with value_or_instance
+template <auto C, typename T>
+    requires is_runtime_task_with_arg_v<decltype(C), T>
+Task FlowBuilder::emplace(T&& value_or_instance) {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Runtime{WorkHandle<void(tf::Runtime&)>{connect_arg<C>, std::forward<T>(value_or_instance)}}
+        )};
+}
+
+// Subflow without value_or_instance
+template <auto C>
+    requires is_subflow_task_v<decltype(C)>
+Task FlowBuilder::emplace() {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Subflow{WorkHandle<void(tf::Subflow&)>{connect_arg<C>}}
+        )};
+}
+
+// Subflow with value_or_instance
+template <auto C, typename T>
+    requires is_subflow_task_with_arg_v<decltype(C), T>
+Task FlowBuilder::emplace(T&& value_or_instance) {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Subflow{WorkHandle<void(tf::Subflow&)>{connect_arg<C>, std::forward<T>(value_or_instance)}}
+        )};
+}
+
+// Condition without value_or_instance
+template <auto C>
+    requires is_condition_task_v<decltype(C)>
+Task FlowBuilder::emplace() {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Condition{WorkHandle<int()>{connect_arg<C>}}
+        )};
+}
+
+// Condition with value_or_instance
+template <auto C, typename T>
+    requires is_condition_task_with_arg_v<decltype(C), T>
+Task FlowBuilder::emplace(T&& value_or_instance) {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::Condition{WorkHandle<int()>{connect_arg<C>, std::forward<T>(value_or_instance)}}
+        )};
+}
+
+// Multi-condition without value_or_instance
+template <auto C>
+    requires is_multi_condition_task_v<decltype(C)>
+Task FlowBuilder::emplace() {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::MultiCondition{WorkHandle<SmallVector<int>()>{connect_arg<C>}}
+        )};
+}
+
+// Multi-condition with value_or_instance
+template <auto C, typename T>
+    requires is_multi_condition_task_with_arg_v<decltype(C), T>
+Task FlowBuilder::emplace(T&& value_or_instance) {
+    return Task{_graph._emplace_back(
+        NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{},
+        nullptr, nullptr, 0,
+        Node::MultiCondition{WorkHandle<SmallVector<int>()>{connect_arg<C>, std::forward<T>(value_or_instance)}}
+        )};
+}
+
+template <auto... C>
+    requires (sizeof...(C) > 1)
+auto FlowBuilder::emplace() {
+    return std::make_tuple(emplace<C>()...);
+}
+template <auto... C, typename... T>
+    requires (sizeof...(C) > 1 && sizeof...(C) == sizeof...(T))
+auto FlowBuilder::emplace(T&&... ts) {
+    return std::make_tuple(emplace<C>(std::forward<T>(ts))...);
+}
+#else
 // Function: emplace
 template <typename C, std::enable_if_t<is_static_task_v<C>, void>*>
 Task FlowBuilder::emplace(C&& c) {
-  return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::Static>{}, std::forward<C>(c)
-  ));
+    return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::Static>{}, std::forward<C>(c)
+                                     ));
 }
 
 // Function: emplace
 template <typename C, std::enable_if_t<is_runtime_task_v<C>, void>*>
 Task FlowBuilder::emplace(C&& c) {
-  return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::Runtime>{}, std::forward<C>(c)
-  ));
+    return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::Runtime>{}, std::forward<C>(c)
+                                     ));
 }
 
 // Function: emplace
 template <typename C, std::enable_if_t<is_subflow_task_v<C>, void>*>
 Task FlowBuilder::emplace(C&& c) {
-  return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::Subflow>{}, std::forward<C>(c)
-  ));
+    return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::Subflow>{}, std::forward<C>(c)
+                                     ));
 }
 
 // Function: emplace
 template <typename C, std::enable_if_t<is_condition_task_v<C>, void>*>
 Task FlowBuilder::emplace(C&& c) {
-  return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::Condition>{}, std::forward<C>(c)
-  ));
+    return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::Condition>{}, std::forward<C>(c)
+                                     ));
 }
 
 // Function: emplace
 template <typename C, std::enable_if_t<is_multi_condition_task_v<C>, void>*>
 Task FlowBuilder::emplace(C&& c) {
-  return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::MultiCondition>{}, std::forward<C>(c)
-  ));
-}
-
-// Function: composed_of
-template <typename T>
-Task FlowBuilder::composed_of(T& object) {
-  auto node = _graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::Module>{}, object
-  );
-  return Task(node);
-}
-
-// Function: placeholder
-inline Task FlowBuilder::placeholder() {
-  auto node = _graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
-    std::in_place_type_t<Node::Placeholder>{}
-  );
-  return Task(node);
+    return Task(_graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::MultiCondition>{}, std::forward<C>(c)
+                                     ));
 }
 
 // Function: emplace
 template <typename... C, std::enable_if_t<(sizeof...(C)>1), void>*>
 auto FlowBuilder::emplace(C&&... cs) {
-  return std::make_tuple(emplace(std::forward<C>(cs))...);
+    return std::make_tuple(emplace(std::forward<C>(cs))...);
 }
+#endif
+// Function: composed_of
+template <typename T>
+Task FlowBuilder::composed_of(T& object) {
+    auto node = _graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::Module>{}, object
+                                     );
+    return Task(node);
+}
+
+// Function: placeholder
+inline Task FlowBuilder::placeholder() {
+    auto node = _graph._emplace_back(NSTATE::NONE, ESTATE::NONE, DefaultTaskParams{}, nullptr, nullptr, 0,
+                                     std::in_place_type_t<Node::Placeholder>{}
+                                     );
+    return Task(node);
+}
+
 
 // Function: erase
 inline void FlowBuilder::erase(Task task) {
 
-  if (!task._node) {
-    return;
-  }
+    if (!task._node) {
+        return;
+    }
 
-  // remove task from its successors' predecessor list
-  for(size_t i=0; i<task._node->_num_successors; ++i) {
-    task._node->_edges[i]->_remove_predecessors(task._node);
-  }
+    // remove task from its successors' predecessor list
+    for(size_t i=0; i<task._node->_num_successors; ++i) {
+        task._node->_edges[i]->_remove_predecessors(task._node);
+    }
 
-  // remove task from its precedessors' successor list
-  for(size_t i=task._node->_num_successors; i<task._node->_edges.size(); ++i) {
-    task._node->_edges[i]->_remove_successors(task._node);
-  }
+    // remove task from its precedessors' successor list
+    for(size_t i=task._node->_num_successors; i<task._node->_edges.size(); ++i) {
+        task._node->_edges[i]->_remove_successors(task._node);
+    }
 
-  _graph._erase(task._node);
+    _graph._erase(task._node);
 }
 
 
@@ -1367,28 +1545,28 @@ inline void FlowBuilder::erase(Task task) {
 template <typename L>
 void FlowBuilder::_linearize(L& keys) {
 
-  auto itr = keys.begin();
-  auto end = keys.end();
+    auto itr = keys.begin();
+    auto end = keys.end();
 
-  if(itr == end) {
-    return;
-  }
+    if(itr == end) {
+        return;
+    }
 
-  auto nxt = itr;
+    auto nxt = itr;
 
-  for(++nxt; nxt != end; ++nxt, ++itr) {
-    itr->_node->_precede(nxt->_node);
-  }
+    for(++nxt; nxt != end; ++nxt, ++itr) {
+        itr->_node->_precede(nxt->_node);
+    }
 }
 
 // Procedure: linearize
 inline void FlowBuilder::linearize(std::vector<Task>& keys) {
-  _linearize(keys);
+    _linearize(keys);
 }
 
 // Procedure: linearize
 inline void FlowBuilder::linearize(std::initializer_list<Task> keys) {
-  _linearize(keys);
+    _linearize(keys);
 }
 
 // ----------------------------------------------------------------------------
@@ -1398,7 +1576,7 @@ inline void FlowBuilder::linearize(std::initializer_list<Task> keys) {
 
 @brief class to construct a subflow graph from the execution of a dynamic task
 
-tf::Subflow is spawned from the execution of a task to dynamically manage a 
+tf::Subflow is spawned from the execution of a task to dynamically manage a
 child graph that may depend on runtime variables.
 You can explicitly join a subflow by calling tf::Subflow::join, respectively.
 By default, the %Taskflow runtime will implicitly join a subflow it is is joinable.
@@ -1431,11 +1609,11 @@ C.precede(D);  // D runs after C
 */
 class Subflow : public FlowBuilder {
 
-  friend class Executor;
-  friend class FlowBuilder;
+    friend class Executor;
+    friend class FlowBuilder;
 
-  public:
-    
+public:
+
     /**
     @brief enables the subflow to join its parent task
 
@@ -1474,19 +1652,19 @@ class Subflow : public FlowBuilder {
     @brief acquires the associated executor
     */
     Executor& executor() noexcept;
-    
+
     /**
     @brief acquires the associated graph
     */
     Graph& graph() { return _graph; }
-    
+
     /**
     @brief specifies whether to keep the subflow after it is joined
 
     @param flag `true` to retain the subflow after it is joined; `false` to discard it
 
     By default, the runtime automatically clears a spawned subflow once it is joined.
-    Setting this flag to `true` allows the application to retain the subflow's structure 
+    Setting this flag to `true` allows the application to retain the subflow's structure
     for post-execution analysis like visualization.
     */
     void retain(bool flag) noexcept;
@@ -1497,10 +1675,10 @@ class Subflow : public FlowBuilder {
     */
     bool retain() const;
 
-  private:
-    
+private:
+
     Subflow(Executor&, Worker&, Node*, Graph&);
-    
+
     Subflow() = delete;
     Subflow(const Subflow&) = delete;
     Subflow(Subflow&&) = delete;
@@ -1512,45 +1690,45 @@ class Subflow : public FlowBuilder {
 
 // Constructor
 inline Subflow::Subflow(Executor& executor, Worker& worker, Node* parent, Graph& graph) :
-  FlowBuilder {graph}, 
-  _executor   {executor}, 
-  _worker     {worker}, 
-  _parent     {parent} {
-  
-  // need to reset since there could have iterative control flow
-  _parent->_nstate &= ~(NSTATE::JOINED_SUBFLOW | NSTATE::RETAIN_SUBFLOW);
+    FlowBuilder {graph},
+    _executor   {executor},
+    _worker     {worker},
+    _parent     {parent} {
 
-  // clear the graph
-  graph.clear();
+    // need to reset since there could have iterative control flow
+    _parent->_nstate &= ~(NSTATE::JOINED_SUBFLOW | NSTATE::RETAIN_SUBFLOW);
+
+    // clear the graph
+    graph.clear();
 }
 
 // Function: joinable
 inline bool Subflow::joinable() const noexcept {
-  return !(_parent->_nstate & NSTATE::JOINED_SUBFLOW);
+    return !(_parent->_nstate & NSTATE::JOINED_SUBFLOW);
 }
 
 // Function: executor
 inline Executor& Subflow::executor() noexcept {
-  return _executor;
+    return _executor;
 }
 
 // Function: retain
 inline void Subflow::retain(bool flag) noexcept {
-  // default value is not to retain 
-  if TF_LIKELY(flag == true) {
-    _parent->_nstate |= NSTATE::RETAIN_SUBFLOW;
-  }
-  else {
-    _parent->_nstate &= ~NSTATE::RETAIN_SUBFLOW;
-  }
+    // default value is not to retain
+    if TF_LIKELY(flag == true) {
+        _parent->_nstate |= NSTATE::RETAIN_SUBFLOW;
+    }
+    else {
+        _parent->_nstate &= ~NSTATE::RETAIN_SUBFLOW;
+    }
 
-  //_parent->_nstate = (_parent->_nstate & ~NSTATE::RETAIN_SUBFLOW) | 
-  //                   (-static_cast<int>(flag) & NSTATE::RETAIN_SUBFLOW);
+    //_parent->_nstate = (_parent->_nstate & ~NSTATE::RETAIN_SUBFLOW) |
+    //                   (-static_cast<int>(flag) & NSTATE::RETAIN_SUBFLOW);
 }
 
 // Function: retain
 inline bool Subflow::retain() const {
-  return _parent->_nstate & NSTATE::RETAIN_SUBFLOW;
+    return _parent->_nstate & NSTATE::RETAIN_SUBFLOW;
 }
 
 }  // end of namespace tf. ---------------------------------------------------

--- a/taskflow/core/graph.hpp
+++ b/taskflow/core/graph.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "../utility/macros.hpp"
 #include "../utility/traits.hpp"
@@ -20,6 +20,10 @@
 #include "topology.hpp"
 #include "tsq.hpp"
 
+#ifdef TF_ENABLE_DELEGATE
+#include "../utility/delegate.hpp"
+#endif
+
 
 /**
 @file graph.hpp
@@ -32,6 +36,14 @@ namespace tf {
 // Class: Graph
 // ----------------------------------------------------------------------------
 
+#ifdef TF_ENABLE_DELEGATE
+template<typename Sig>
+using WorkHandle = tf::delegate<Sig>;
+#else
+#include <functional>
+template<typename Sig>
+using WorkHandle = std::function<Sig>;
+#endif
 
 /**
 @class Graph
@@ -50,49 +62,49 @@ A graph object is move-only.
 */
 class Graph : public std::vector<std::unique_ptr<Node>> {
 
-  friend class Node;
-  friend class FlowBuilder;
-  friend class Subflow;
-  friend class Taskflow;
-  friend class Executor;
+    friend class Node;
+    friend class FlowBuilder;
+    friend class Subflow;
+    friend class Taskflow;
+    friend class Executor;
 
-  public:
+public:
 
-  /**
+    /**
   @brief constructs a graph object
   */
-  Graph() = default;
+    Graph() = default;
 
-  /**
+    /**
   @brief disabled copy constructor
   */
-  Graph(const Graph&) = delete;
+    Graph(const Graph&) = delete;
 
-  /**
+    /**
   @brief constructs a graph using move semantics
   */
-  Graph(Graph&&) = default;
+    Graph(Graph&&) = default;
 
-  /**
+    /**
   @brief disabled copy assignment operator
   */
-  Graph& operator = (const Graph&) = delete;
+    Graph& operator = (const Graph&) = delete;
 
-  /**
+    /**
   @brief assigns a graph using move semantics
   */
-  Graph& operator = (Graph&&) = default;
-  
+    Graph& operator = (Graph&&) = default;
 
-  private:
 
-  void _erase(Node*);
-  
-  /**
+private:
+
+    void _erase(Node*);
+
+    /**
   @private
   */
-  template <typename ...ArgsT>
-  Node* _emplace_back(ArgsT&&...);
+    template <typename ...ArgsT>
+    Node* _emplace_back(ArgsT&&...);
 };
 
 // ----------------------------------------------------------------------------
@@ -102,21 +114,21 @@ class Graph : public std::vector<std::unique_ptr<Node>> {
 /**
 @class TaskParams
 
-@brief class to create a task parameter object 
+@brief class to create a task parameter object
 */
 class TaskParams {
 
-  public:
+public:
 
-  /**
+    /**
   @brief name of the task
   */
-  std::string name;
+    std::string name;
 
-  /**
+    /**
   @brief C-styled pointer to user data
   */
-  void* data {nullptr};
+    void* data {nullptr};
 };
 
 /**
@@ -136,9 +148,9 @@ Task parameters can be specified in one of the following types:
 */
 template <typename P>
 constexpr bool is_task_params_v =
-  std::is_same_v<std::decay_t<P>, TaskParams> ||
-  std::is_same_v<std::decay_t<P>, DefaultTaskParams> ||
-  std::is_constructible_v<std::string, P>;
+    std::is_same_v<std::decay_t<P>, TaskParams> ||
+    std::is_same_v<std::decay_t<P>, DefaultTaskParams> ||
+    std::is_constructible_v<std::string, P>;
 
 // ----------------------------------------------------------------------------
 // Node
@@ -149,189 +161,188 @@ constexpr bool is_task_params_v =
 */
 class Node {
 
-  friend class Graph;
-  friend class Task;
-  friend class AsyncTask;
-  friend class TaskView;
-  friend class Taskflow;
-  friend class Executor;
-  friend class FlowBuilder;
-  friend class Subflow;
-  friend class Runtime;
-  friend class AnchorGuard;
-  friend class PreemptionGuard;
+    friend class Graph;
+    friend class Task;
+    friend class AsyncTask;
+    friend class TaskView;
+    friend class Taskflow;
+    friend class Executor;
+    friend class FlowBuilder;
+    friend class Subflow;
+    friend class Runtime;
+    friend class AnchorGuard;
+    friend class PreemptionGuard;
 
-  //template <typename T>
-  //friend class Freelist;
+//template <typename T>
+//friend class Freelist;
 
 #ifdef TF_ENABLE_TASK_POOL
-  TF_ENABLE_POOLABLE_ON_THIS;
+    TF_ENABLE_POOLABLE_ON_THIS;
 #endif
 
-  using Placeholder = std::monostate;
+    using Placeholder = std::monostate;
 
-  // static work handle
-  struct Static {
+    // static work handle
+    struct Static {
 
-    template <typename C>
-    Static(C&&);
+        template <typename C>
+        Static(C&& c);
 
-    std::function<void()> work;
-  };
-  
-  // runtime work handle
-  struct Runtime {
+        WorkHandle<void()> work;
+    };
+    // runtime work handle
+    struct Runtime {
 
-    template <typename C>
-    Runtime(C&&);
+        template <typename C>
+        Runtime(C&&);
 
-    std::function<void(tf::Runtime&)> work;
-  };
+        WorkHandle<void(tf::Runtime&)> work;
+    };
 
-  // subflow work handle
-  struct Subflow {
+    // subflow work handle
+    struct Subflow {
 
-    template <typename C>
-    Subflow(C&&);
+        template <typename C>
+        Subflow(C&&);
 
-    std::function<void(tf::Subflow&)> work;
-    Graph subgraph;
-  };
+        WorkHandle<void(tf::Subflow&)> work;
+        Graph subgraph;
+    };
 
-  // condition work handle
-  struct Condition {
+    // condition work handle
+    struct Condition {
 
-    template <typename C>
-    Condition(C&&);
-    
-    std::function<int()> work;
-  };
+        template <typename C>
+        Condition(C&&);
 
-  // multi-condition work handle
-  struct MultiCondition {
+        WorkHandle<int()> work;
+    };
 
-    template <typename C>
-    MultiCondition(C&&);
+    // multi-condition work handle
+    struct MultiCondition {
 
-    std::function<SmallVector<int>()> work;
-  };
+        template <typename C>
+        MultiCondition(C&&);
 
-  // module work handle
-  struct Module {
+        WorkHandle<SmallVector<int>()> work;
+    };
 
-    template <typename T>
-    Module(T&);
+    // module work handle
+    struct Module {
 
-    Graph& graph;
-  };
+        template <typename T>
+        Module(T&);
 
-  // Async work
-  struct Async {
+        Graph& graph;
+    };
 
-    template <typename T>
-    Async(T&&);
+    // Async work
+    struct Async {
 
-    std::variant<
-      std::function<void()>, 
-      std::function<void(tf::Runtime&)>,       // silent async
-      std::function<void(tf::Runtime&, bool)>  // async
-    > work;
-  };
-  
-  // silent dependent async
-  struct DependentAsync {
-    
-    template <typename C>
-    DependentAsync(C&&);
-    
-    std::variant<
-      std::function<void()>, 
-      std::function<void(tf::Runtime&)>,       // silent async
-      std::function<void(tf::Runtime&, bool)>  // async
-    > work;
-   
-    std::atomic<size_t> use_count {1};
-    std::atomic<ASTATE::underlying_type> state {ASTATE::UNFINISHED};
-  };
+        template <typename T>
+        Async(T&&);
 
-  using handle_t = std::variant<
-    Placeholder,      // placeholder
-    Static,           // static tasking
-    Runtime,          // runtime tasking
-    Subflow,          // subflow tasking
-    Condition,        // conditional tasking
-    MultiCondition,   // multi-conditional tasking
-    Module,           // composable tasking
-    Async,            // async tasking
-    DependentAsync    // dependent async tasking
-  >;
+        std::variant<
+            std::function<void()>,
+            WorkHandle<void(tf::Runtime&)>,       // silent async
+            std::function<void(tf::Runtime&, bool)>  // async
+            > work;
+    };
 
-  struct Semaphores {
-    SmallVector<Semaphore*> to_acquire;
-    SmallVector<Semaphore*> to_release;
-  };
+    // silent dependent async
+    struct DependentAsync {
 
-  public:
+        template <typename C>
+        DependentAsync(C&&);
 
-  // variant index
-  constexpr static auto PLACEHOLDER     = get_index_v<Placeholder, handle_t>;
-  constexpr static auto STATIC          = get_index_v<Static, handle_t>;
-  constexpr static auto RUNTIME         = get_index_v<Runtime, handle_t>;
-  constexpr static auto SUBFLOW         = get_index_v<Subflow, handle_t>;
-  constexpr static auto CONDITION       = get_index_v<Condition, handle_t>;
-  constexpr static auto MULTI_CONDITION = get_index_v<MultiCondition, handle_t>;
-  constexpr static auto MODULE          = get_index_v<Module, handle_t>;
-  constexpr static auto ASYNC           = get_index_v<Async, handle_t>;
-  constexpr static auto DEPENDENT_ASYNC = get_index_v<DependentAsync, handle_t>;
+        std::variant<
+            std::function<void()>,
+            WorkHandle<void(tf::Runtime&)>,       // silent async
+            std::function<void(tf::Runtime&, bool)>  // async
+            > work;
 
-  Node() = default;
-  
-  template <typename... Args>
-  Node(nstate_t, estate_t, const TaskParams&, Topology*, Node*, size_t, Args&&...);
-  
-  template <typename... Args>
-  Node(nstate_t, estate_t, const DefaultTaskParams&, Topology*, Node*, size_t, Args&&...);
+        std::atomic<size_t> use_count {1};
+        std::atomic<ASTATE::underlying_type> state {ASTATE::UNFINISHED};
+    };
 
-  size_t num_successors() const;
-  size_t num_predecessors() const;
-  size_t num_strong_dependencies() const;
-  size_t num_weak_dependencies() const;
+    using handle_t = std::variant<
+        Placeholder,      // placeholder
+        Static,           // static tasking
+        Runtime,          // runtime tasking
+        Subflow,          // subflow tasking
+        Condition,        // conditional tasking
+        MultiCondition,   // multi-conditional tasking
+        Module,           // composable tasking
+        Async,            // async tasking
+        DependentAsync    // dependent async tasking
+        >;
 
-  const std::string& name() const;
+    struct Semaphores {
+        SmallVector<Semaphore*> to_acquire;
+        SmallVector<Semaphore*> to_release;
+    };
 
-  private:
-  
-  nstate_t _nstate              {NSTATE::NONE};
-  std::atomic<estate_t> _estate {ESTATE::NONE};
+public:
 
-  std::string _name;
-  
-  void* _data {nullptr};
-  
-  Topology* _topology {nullptr};
-  Node* _parent {nullptr};
+    // variant index
+    constexpr static auto PLACEHOLDER     = get_index_v<Placeholder, handle_t>;
+    constexpr static auto STATIC          = get_index_v<Static, handle_t>;
+    constexpr static auto RUNTIME         = get_index_v<Runtime, handle_t>;
+    constexpr static auto SUBFLOW         = get_index_v<Subflow, handle_t>;
+    constexpr static auto CONDITION       = get_index_v<Condition, handle_t>;
+    constexpr static auto MULTI_CONDITION = get_index_v<MultiCondition, handle_t>;
+    constexpr static auto MODULE          = get_index_v<Module, handle_t>;
+    constexpr static auto ASYNC           = get_index_v<Async, handle_t>;
+    constexpr static auto DEPENDENT_ASYNC = get_index_v<DependentAsync, handle_t>;
 
-  size_t _num_successors {0};
-  SmallVector<Node*, 4> _edges;
+    Node() = default;
 
-  std::atomic<size_t> _join_counter {0};
-  
-  handle_t _handle;
-  
-  std::unique_ptr<Semaphores> _semaphores;
-  
-  std::exception_ptr _exception_ptr {nullptr};
+    template <typename... Args>
+    Node(nstate_t, estate_t, const TaskParams&, Topology*, Node*, size_t, Args&&...);
 
-  bool _is_cancelled() const;
-  bool _is_conditioner() const;
-  bool _is_preempted() const;
-  bool _acquire_all(SmallVector<Node*>&);
-  void _release_all(SmallVector<Node*>&);
-  void _precede(Node*);
-  void _set_up_join_counter();
-  void _rethrow_exception();
-  void _remove_successors(Node*);
-  void _remove_predecessors(Node*);
+    template <typename... Args>
+    Node(nstate_t, estate_t, const DefaultTaskParams&, Topology*, Node*, size_t, Args&&...);
+
+    size_t num_successors() const;
+    size_t num_predecessors() const;
+    size_t num_strong_dependencies() const;
+    size_t num_weak_dependencies() const;
+
+    const std::string& name() const;
+
+private:
+
+    nstate_t _nstate              {NSTATE::NONE};
+    std::atomic<estate_t> _estate {ESTATE::NONE};
+
+    std::string _name;
+
+    void* _data {nullptr};
+
+    Topology* _topology {nullptr};
+    Node* _parent {nullptr};
+
+    size_t _num_successors {0};
+    SmallVector<Node*, 4> _edges;
+
+    std::atomic<size_t> _join_counter {0};
+
+    handle_t _handle;
+
+    std::unique_ptr<Semaphores> _semaphores;
+
+    std::exception_ptr _exception_ptr {nullptr};
+
+    bool _is_cancelled() const;
+    bool _is_conditioner() const;
+    bool _is_preempted() const;
+    bool _acquire_all(SmallVector<Node*>&);
+    void _release_all(SmallVector<Node*>&);
+    void _precede(Node*);
+    void _set_up_join_counter();
+    void _rethrow_exception();
+    void _remove_successors(Node*);
+    void _remove_predecessors(Node*);
 };
 
 // ----------------------------------------------------------------------------
@@ -351,9 +362,9 @@ inline ObjectPool<Node> _task_pool;
 template <typename... ArgsT>
 TF_FORCE_INLINE Node* animate(ArgsT&&... args) {
 #ifdef TF_ENABLE_TASK_POOL
-  return _task_pool.animate(std::forward<ArgsT>(args)...);
+    return _task_pool.animate(std::forward<ArgsT>(args)...);
 #else
-  return new Node(std::forward<ArgsT>(args)...);
+    return new Node(std::forward<ArgsT>(args)...);
 #endif
 }
 
@@ -362,9 +373,9 @@ TF_FORCE_INLINE Node* animate(ArgsT&&... args) {
 */
 TF_FORCE_INLINE void recycle(Node* ptr) {
 #ifdef TF_ENABLE_TASK_POOL
-  _task_pool.recycle(ptr);
+    _task_pool.recycle(ptr);
 #else
-  delete ptr;
+    delete ptr;
 #endif
 }
 
@@ -376,6 +387,7 @@ TF_FORCE_INLINE void recycle(Node* ptr) {
 template <typename C>
 Node::Static::Static(C&& c) : work {std::forward<C>(c)} {
 }
+
 
 // ----------------------------------------------------------------------------
 // Definition for Node::Runtime
@@ -402,7 +414,7 @@ Node::Subflow::Subflow(C&& c) : work {std::forward<C>(c)} {
 // Constructor
 template <typename C>
 Node::Condition::Condition(C&& c) : work {std::forward<C>(c)} {
-}                                        
+}
 
 // ----------------------------------------------------------------------------
 // Definition for Node::MultiCondition
@@ -447,41 +459,41 @@ Node::DependentAsync::DependentAsync(C&& c) : work {std::forward<C>(c)} {
 // Constructor
 template <typename... Args>
 Node::Node(
-  nstate_t nstate,
-  estate_t estate,
-  const TaskParams& params,
-  Topology* topology, 
-  Node* parent, 
-  size_t join_counter,
-  Args&&... args
-) :
-  _nstate       {nstate},
-  _estate       {estate},
-  _name         {params.name},
-  _data         {params.data},
-  _topology     {topology},
-  _parent       {parent},
-  _join_counter {join_counter},
-  _handle       {std::forward<Args>(args)...} {
+    nstate_t nstate,
+    estate_t estate,
+    const TaskParams& params,
+    Topology* topology,
+    Node* parent,
+    size_t join_counter,
+    Args&&... args
+    ) :
+    _nstate       {nstate},
+    _estate       {estate},
+    _name         {params.name},
+    _data         {params.data},
+    _topology     {topology},
+    _parent       {parent},
+    _join_counter {join_counter},
+    _handle       {std::forward<Args>(args)...} {
 }
 
 // Constructor
 template <typename... Args>
 Node::Node(
-  nstate_t nstate,
-  estate_t estate,
-  const DefaultTaskParams&,
-  Topology* topology, 
-  Node* parent, 
-  size_t join_counter,
-  Args&&... args
-) :
-  _nstate       {nstate},
-  _estate       {estate},
-  _topology     {topology},
-  _parent       {parent},
-  _join_counter {join_counter},
-  _handle       {std::forward<Args>(args)...} {
+    nstate_t nstate,
+    estate_t estate,
+    const DefaultTaskParams&,
+    Topology* topology,
+    Node* parent,
+    size_t join_counter,
+    Args&&... args
+    ) :
+    _nstate       {nstate},
+    _estate       {estate},
+    _topology     {topology},
+    _parent       {parent},
+    _join_counter {join_counter},
+    _handle       {std::forward<Args>(args)...} {
 }
 
 // Procedure: _precede
@@ -490,129 +502,129 @@ u successor   layout: s1, s2, s3, p1, p2 (num_successors = 3)
 v predecessor layout: s1, p1, p2
 
 add a new successor: u->v
-u successor   layout: 
+u successor   layout:
   s1, s2, s3, p1, p2, v (push_back v)
   s1, s2, s3, v, p2, p1 (swap adj[num_successors] with adj[n-1])
-v predecessor layout: 
+v predecessor layout:
   s1, p1, p2, u         (push_back u)
-*/ 
+*/
 inline void Node::_precede(Node* v) {
-  _edges.push_back(v);
-  std::swap(_edges[_num_successors++], _edges[_edges.size() - 1]);
-  v->_edges.push_back(this);
+    _edges.push_back(v);
+    std::swap(_edges[_num_successors++], _edges[_edges.size() - 1]);
+    v->_edges.push_back(this);
 }
 
 // Function: _remove_successors
 inline void Node::_remove_successors(Node* node) {
-  auto sit = std::remove(_edges.begin(), _edges.begin() + _num_successors, node);
-  size_t new_num_successors = std::distance(_edges.begin(), sit);
-  std::move(_edges.begin() + _num_successors, _edges.end(), sit);
-  _edges.resize(_edges.size() - (_num_successors - new_num_successors));
-  _num_successors = new_num_successors;
+    auto sit = std::remove(_edges.begin(), _edges.begin() + _num_successors, node);
+    size_t new_num_successors = std::distance(_edges.begin(), sit);
+    std::move(_edges.begin() + _num_successors, _edges.end(), sit);
+    _edges.resize(_edges.size() - (_num_successors - new_num_successors));
+    _num_successors = new_num_successors;
 }
 
 // Function: _remove_predecessors
 inline void Node::_remove_predecessors(Node* node) {
-  _edges.erase( 
-    std::remove(_edges.begin() + _num_successors, _edges.end(), node), _edges.end()
-  );
+    _edges.erase(
+        std::remove(_edges.begin() + _num_successors, _edges.end(), node), _edges.end()
+        );
 }
 
 // Function: num_successors
 inline size_t Node::num_successors() const {
-  return _num_successors;
+    return _num_successors;
 }
 
 // Function: predecessors
 inline size_t Node::num_predecessors() const {
-  return _edges.size() - _num_successors;
+    return _edges.size() - _num_successors;
 }
 
 // Function: num_weak_dependencies
 inline size_t Node::num_weak_dependencies() const {
-  size_t n = 0;
-  for(size_t i=_num_successors; i<_edges.size(); i++) {
-    n += _edges[i]->_is_conditioner();
-  }
-  return n;
+    size_t n = 0;
+    for(size_t i=_num_successors; i<_edges.size(); i++) {
+        n += _edges[i]->_is_conditioner();
+    }
+    return n;
 }
 
 // Function: num_strong_dependencies
 inline size_t Node::num_strong_dependencies() const {
-  size_t n = 0;
-  for(size_t i=_num_successors; i<_edges.size(); i++) {
-    n += !_edges[i]->_is_conditioner();
-  }
-  return n;
+    size_t n = 0;
+    for(size_t i=_num_successors; i<_edges.size(); i++) {
+        n += !_edges[i]->_is_conditioner();
+    }
+    return n;
 }
 
 // Function: name
 inline const std::string& Node::name() const {
-  return _name;
+    return _name;
 }
 
 // Function: _is_conditioner
 inline bool Node::_is_conditioner() const {
-  return _handle.index() == Node::CONDITION ||
-         _handle.index() == Node::MULTI_CONDITION;
+    return _handle.index() == Node::CONDITION ||
+           _handle.index() == Node::MULTI_CONDITION;
 }
 
 // Function: _is_preempted
 inline bool Node::_is_preempted() const {
-  return _nstate & NSTATE::PREEMPTED;
+    return _nstate & NSTATE::PREEMPTED;
 }
 
 // Function: _is_cancelled
 // we currently only support cancellation of taskflow (no async task)
 inline bool Node::_is_cancelled() const {
-  return (_topology && (_topology->_estate.load(std::memory_order_relaxed) & ESTATE::CANCELLED)) 
-         ||
-         (_parent && (_parent->_estate.load(std::memory_order_relaxed) & ESTATE::CANCELLED));
+    return (_topology && (_topology->_estate.load(std::memory_order_relaxed) & ESTATE::CANCELLED))
+    ||
+        (_parent && (_parent->_estate.load(std::memory_order_relaxed) & ESTATE::CANCELLED));
 }
 
 // Procedure: _set_up_join_counter
 inline void Node::_set_up_join_counter() {
-  size_t c = 0;
-  //for(auto p : _predecessors) {
-  for(size_t i=_num_successors; i<_edges.size(); i++) {
-    bool is_cond = _edges[i]->_is_conditioner();
-    _nstate = (_nstate + is_cond) | (is_cond * NSTATE::CONDITIONED);  // weak dependency
-    c += !is_cond;  // strong dependency
-  }
-  _join_counter.store(c, std::memory_order_relaxed);
+    size_t c = 0;
+    //for(auto p : _predecessors) {
+    for(size_t i=_num_successors; i<_edges.size(); i++) {
+        bool is_cond = _edges[i]->_is_conditioner();
+        _nstate = (_nstate + is_cond) | (is_cond * NSTATE::CONDITIONED);  // weak dependency
+        c += !is_cond;  // strong dependency
+    }
+    _join_counter.store(c, std::memory_order_relaxed);
 }
 
 // Procedure: _rethrow_exception
 inline void Node::_rethrow_exception() {
-  if(_exception_ptr) {
-    auto e = _exception_ptr;
-    _exception_ptr = nullptr;
-    std::rethrow_exception(e);
-  }
+    if(_exception_ptr) {
+        auto e = _exception_ptr;
+        _exception_ptr = nullptr;
+        std::rethrow_exception(e);
+    }
 }
 
 // Function: _acquire_all
 inline bool Node::_acquire_all(SmallVector<Node*>& nodes) {
-  // assert(_semaphores != nullptr);
-  auto& to_acquire = _semaphores->to_acquire;
-  for(size_t i = 0; i < to_acquire.size(); ++i) {
-    if(!to_acquire[i]->_try_acquire_or_wait(this)) {
-      for(size_t j = 1; j <= i; ++j) {
-        to_acquire[i-j]->_release(nodes);
-      }
-      return false;
+    // assert(_semaphores != nullptr);
+    auto& to_acquire = _semaphores->to_acquire;
+    for(size_t i = 0; i < to_acquire.size(); ++i) {
+        if(!to_acquire[i]->_try_acquire_or_wait(this)) {
+            for(size_t j = 1; j <= i; ++j) {
+                to_acquire[i-j]->_release(nodes);
+            }
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 // Function: _release_all
 inline void Node::_release_all(SmallVector<Node*>& nodes) {
-  // assert(_semaphores != nullptr);
-  auto& to_release = _semaphores->to_release;
-  for(const auto& sem : to_release) {
-    sem->_release(nodes);
-  }
+    // assert(_semaphores != nullptr);
+    auto& to_release = _semaphores->to_release;
+    for(const auto& sem : to_release) {
+        sem->_release(nodes);
+    }
 }
 
 
@@ -626,21 +638,21 @@ inline void Node::_release_all(SmallVector<Node*>& nodes) {
 */
 class AnchorGuard {
 
-  public:
-  
-  // anchor is at estate as it may be accessed by multiple threads (e.g., corun's
-  // parent with tear_down_async's parent).
-  AnchorGuard(Node* node) : _node{node} { 
-    _node->_estate.fetch_or(ESTATE::ANCHORED, std::memory_order_relaxed);
-  }
+public:
 
-  ~AnchorGuard() {
-    _node->_estate.fetch_and(~ESTATE::ANCHORED, std::memory_order_relaxed);
-  }
-  
-  private:
+    // anchor is at estate as it may be accessed by multiple threads (e.g., corun's
+    // parent with tear_down_async's parent).
+    AnchorGuard(Node* node) : _node{node} {
+        _node->_estate.fetch_or(ESTATE::ANCHORED, std::memory_order_relaxed);
+    }
 
-  Node* _node;
+    ~AnchorGuard() {
+        _node->_estate.fetch_and(~ESTATE::ANCHORED, std::memory_order_relaxed);
+    }
+
+private:
+
+    Node* _node;
 };
 
 
@@ -650,10 +662,10 @@ class AnchorGuard {
 
 // Function: erase
 inline void Graph::_erase(Node* node) {
-  erase(
-    std::remove_if(begin(), end(), [&](auto& p){ return p.get() == node; }),
-    end()
-  );
+    erase(
+        std::remove_if(begin(), end(), [&](auto& p){ return p.get() == node; }),
+        end()
+        );
 }
 
 /**
@@ -661,8 +673,8 @@ inline void Graph::_erase(Node* node) {
 */
 template <typename ...ArgsT>
 Node* Graph::_emplace_back(ArgsT&&... args) {
-  push_back(std::make_unique<Node>(std::forward<ArgsT>(args)...));
-  return back().get();
+    push_back(std::make_unique<Node>(std::forward<ArgsT>(args)...));
+    return back().get();
 }
 
 // ----------------------------------------------------------------------------
@@ -723,17 +735,17 @@ namespace detail {
 */
 template <typename T>
 TF_FORCE_INLINE Node* get_node_ptr(T& node) {
-  using U = std::decay_t<T>;
-  if constexpr (std::is_same_v<U, Node*>) {
-    return node;
-  } 
-  else if constexpr (std::is_same_v<U, std::unique_ptr<Node>>) {
-    return node.get();
-  } 
-  else {
-    static_assert(dependent_false_v<T>, "Unsupported type for get_node_ptr");
-  }
-} 
+    using U = std::decay_t<T>;
+    if constexpr (std::is_same_v<U, Node*>) {
+        return node;
+    }
+    else if constexpr (std::is_same_v<U, std::unique_ptr<Node>>) {
+        return node.get();
+    }
+    else {
+        static_assert(dependent_false_v<T>, "Unsupported type for get_node_ptr");
+    }
+}
 
 }  // end of namespace tf::detail ---------------------------------------------
 

--- a/taskflow/core/runtime.hpp
+++ b/taskflow/core/runtime.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "executor.hpp"
 
@@ -36,19 +36,19 @@ To understand how %Taskflow schedules a runtime task, please refer to @ref Runti
 */
 class Runtime {
 
-  friend class Executor;
-  friend class FlowBuilder;
-  friend class PreemptionGuard;
-  friend class Algorithm;
-  
-  #define TF_RUNTIME_CHECK_CALLER(msg) \
-  if(pt::this_worker != &_worker) {    \
-    TF_THROW(msg);                     \
-  }
+    friend class Executor;
+    friend class FlowBuilder;
+    friend class PreemptionGuard;
+    friend class Algorithm;
 
-  public:
-  
-  /**
+#define TF_RUNTIME_CHECK_CALLER(msg) \
+    if(pt::this_worker != &_worker) {    \
+            TF_THROW(msg);                     \
+    }
+
+public:
+
+    /**
   @brief obtains the running executor
 
   The running executor of a runtime task is the executor that runs
@@ -63,14 +63,14 @@ class Runtime {
   executor.run(taskflow).wait();
   @endcode
   */
-  Executor& executor();
-  
-  /**
+    Executor& executor();
+
+    /**
   @brief acquire a reference to the underlying worker
   */
-  inline Worker& worker();
+    inline Worker& worker();
 
-  /**
+    /**
   @brief schedules an active task immediately to the worker's queue
 
   @param task the given active task to schedule immediately
@@ -109,14 +109,14 @@ class Runtime {
   This method can only be called by the parent worker of this runtime,
   or the behavior is undefined.
   */
-  void schedule(Task task);
-  
-  /**
+    void schedule(Task task);
+
+    /**
   @brief runs the given callable asynchronously
 
   @tparam F callable type
   @param f callable object
-    
+
   The method creates an asynchronous task to launch the given
   function on the given arguments.
   The difference to tf::Executor::async is that the created asynchronous task
@@ -133,12 +133,12 @@ class Runtime {
     fu1.get();
     fu2.get();
     assert(counter == 2);
-    
+
     // spawn 100 asynchronous tasks from the worker of the runtime
     for(int i=0; i<100; i++) {
       rt.silent_async([&](){ counter++; });
     }
-    
+
     // wait for the 100 asynchronous tasks to finish
     rt.corun();
     assert(counter == 102);
@@ -150,29 +150,29 @@ class Runtime {
   For example, the code below spawns 100 tasks from the worker of
   a runtime, and each of the 100 tasks spawns another task
   that will be run by another worker.
-  
+
   @code{.cpp}
   std::atomic<int> counter(0);
   taskflow.emplace([&](tf::Runtime& rt){
     // worker of the runtime spawns 100 tasks each spawning another task
     // that will be run by another worker
     for(int i=0; i<100; i++) {
-      rt.async([&](){ 
-        counter++; 
+      rt.async([&](){
+        counter++;
         rt.async([](){ counter++; });
       });
     }
-    
+
     // wait for the 200 asynchronous tasks to finish
     rt.corun();
     assert(counter == 200);
   });
   @endcode
   */
-  template <typename F>
-  auto async(F&& f);
-  
-  /**
+    template <typename F>
+    auto async(F&& f);
+
+    /**
   @brief runs the given callable asynchronously
 
   @tparam F callable type
@@ -191,10 +191,10 @@ class Runtime {
   @endcode
 
   */
-  template <typename P, typename F>
-  auto async(P&& params, F&& f);
+    template <typename P, typename F>
+    auto async(P&& params, F&& f);
 
-  /**
+    /**
   @brief runs the given function asynchronously without returning any future object
 
   @tparam F callable type
@@ -216,10 +216,10 @@ class Runtime {
 
   This member function is thread-safe.
   */
-  template <typename F>
-  void silent_async(F&& f);
-  
-  /**
+    template <typename F>
+    void silent_async(F&& f);
+
+    /**
   @brief runs the given function asynchronously without returning any future object
 
   @tparam F callable type
@@ -235,12 +235,12 @@ class Runtime {
   });
   @endcode
   */
-  template <typename P, typename F>
-  void silent_async(P&& params, F&& f);
-  
-  /**
+    template <typename P, typename F>
+    void silent_async(P&& params, F&& f);
+
+    /**
   @brief co-runs the given target and waits until it completes
-  
+
   A corunnable target must have `tf::Graph& T::graph()` defined.
 
   // co-run a taskflow and wait until all tasks complete
@@ -254,23 +254,23 @@ class Runtime {
   executor.run(taskflow2).wait();
   @endcode
 
-  Although tf::Runtime::corun blocks until the operation completes, 
+  Although tf::Runtime::corun blocks until the operation completes,
   the caller thread (worker) is not blocked (e.g., sleeping or holding any lock).
-  Instead, the caller thread joins the work-stealing loop of the executor 
+  Instead, the caller thread joins the work-stealing loop of the executor
   and returns when all tasks in the target completes.
-  
+
   @attention
   This method can only be called by the parent worker of this runtime,
   or the behavior is undefined.
   */
-  template <typename T>
-  void corun(T&& target);
+    template <typename T>
+    void corun(T&& target);
 
-  /**
+    /**
   @brief corun all tasks spawned by this runtime with other workers
 
   Coruns all tasks spawned by this runtime with other workers until all these tasks finish.
-    
+
   @code{.cpp}
   std::atomic<size_t> counter{0};
   taskflow.emplace([&](tf::Runtime& rt){
@@ -280,7 +280,7 @@ class Runtime {
     }
     rt.corun();
     assert(counter == 100);
-    
+
     // spawn another 100 async tasks and wait
     for(int i=0; i<100; i++) {
       rt.silent_async([&](){ counter++; });
@@ -294,102 +294,102 @@ class Runtime {
   This method can only be called by the parent worker of this runtime,
   or the behavior is undefined.
   */
-  void corun();
+    void corun();
 
-  /**
+    /**
   @brief equivalent to tf::Runtime::corun - just an alias for legacy purpose
   */
-  void corun_all();
+    void corun_all();
 
-  /**
+    /**
   @brief This method verifies if the task has been cancelled.
   */
-  bool is_cancelled();
+    bool is_cancelled();
 
 protected:
-  /**
+    /**
   @private
   */
-  explicit Runtime(Executor&, Worker&, Node*);
-  
-  /**
+    explicit Runtime(Executor&, Worker&, Node*);
+
+    /**
   @private
   */
-  Executor& _executor;
-  
-  /**
+    Executor& _executor;
+
+    /**
   @private
   */
-  Worker& _worker;
-  
-  /**
+    Worker& _worker;
+
+    /**
   @private
   */
-  Node* _parent;
-  
-  /**
+    Node* _parent;
+
+    /**
   @private
   */
-  bool _preempted {false};
+    bool _preempted {false};
 };
 
 // constructor
 inline Runtime::Runtime(Executor& executor, Worker& worker, Node* parent) :
-  _executor {executor},
-  _worker   {worker},
-  _parent   {parent} {
+    _executor {executor},
+    _worker   {worker},
+    _parent   {parent} {
 }
 
 // Function: executor
 inline Executor& Runtime::executor() {
-  return _executor;
+    return _executor;
 }
 
 // Function: worker
 inline Worker& Runtime::worker() {
-  return _worker;
+    return _worker;
 }
 
 // Procedure: schedule
 inline void Runtime::schedule(Task task) {
-  
-  auto node = task._node;
-  // need to keep the invariant: when scheduling a task, the task must have
-  // zero dependency (join counter is 0)
-  // or we can encounter bug when inserting a nested flow (e.g., module task)
-  node->_join_counter.store(0, std::memory_order_relaxed);
 
-  auto& j = node->_parent ? node->_parent->_join_counter :
-                            node->_topology->_join_counter;
-  j.fetch_add(1, std::memory_order_relaxed);
-  _executor._schedule(_worker, node);
+    auto node = task._node;
+    // need to keep the invariant: when scheduling a task, the task must have
+    // zero dependency (join counter is 0)
+    // or we can encounter bug when inserting a nested flow (e.g., module task)
+    node->_join_counter.store(0, std::memory_order_relaxed);
+
+    auto& j = node->_parent ? node->_parent->_join_counter :
+                  node->_topology->_join_counter;
+    j.fetch_add(1, std::memory_order_relaxed);
+    _executor._schedule(_worker, node);
 }
 
 // Procedure: corun
 template <typename T>
 void Runtime::corun(T&& target) {
-  static_assert(has_graph_v<T>, "target must define a member function 'Graph& graph()'");
-  _executor._corun_graph(*pt::this_worker, _parent, target.graph().begin(), target.graph().end());
+    static_assert(has_graph_v<T>, "target must define a member function 'Graph& graph()'");
+    _executor._corun_graph(*pt::this_worker, _parent, target.graph().begin(), target.graph().end());
 }
 
 // Function: corun
 inline void Runtime::corun() {
-  {
-    AnchorGuard anchor(_parent);
-    _executor._corun_until(_worker, [this] () -> bool {
-      return _parent->_join_counter.load(std::memory_order_acquire) == 0;
-    });
-  }
-  _parent->_rethrow_exception();
+    {
+        AnchorGuard anchor(_parent);
+        _executor._corun_until(_worker, [this] () -> bool {
+            return _parent->_join_counter.load(std::memory_order_acquire) == 0;
+        });
+    }
+    _parent->_rethrow_exception();
 }
 
 // Function: corun_all
 inline void Runtime::corun_all() {
-  corun();
+    corun();
 }
 
-inline bool Runtime::is_cancelled() { 
-  return _parent->_is_cancelled(); 
+inline bool Runtime::is_cancelled() {
+    return _parent->_is_cancelled();
 }
 
 // ------------------------------------
@@ -399,16 +399,16 @@ inline bool Runtime::is_cancelled() {
 // Function: silent_async
 template <typename F>
 void Runtime::silent_async(F&& f) {
-  silent_async(DefaultTaskParams{}, std::forward<F>(f));
+    silent_async(DefaultTaskParams{}, std::forward<F>(f));
 }
 
 // Function: silent_async
 template <typename P, typename F>
 void Runtime::silent_async(P&& params, F&& f) {
-  _parent->_join_counter.fetch_add(1, std::memory_order_relaxed);
-  _executor._silent_async(
-    std::forward<P>(params), std::forward<F>(f), _parent->_topology, _parent
-  );
+    _parent->_join_counter.fetch_add(1, std::memory_order_relaxed);
+    _executor._silent_async(
+        std::forward<P>(params), std::forward<F>(f), _parent->_topology, _parent
+        );
 }
 
 // ------------------------------------
@@ -418,16 +418,16 @@ void Runtime::silent_async(P&& params, F&& f) {
 // Function: async
 template <typename F>
 auto Runtime::async(F&& f) {
-  return async(DefaultTaskParams{}, std::forward<F>(f));
+    return async(DefaultTaskParams{}, std::forward<F>(f));
 }
 
 // Function: async
 template <typename P, typename F>
 auto Runtime::async(P&& params, F&& f) {
-  _parent->_join_counter.fetch_add(1, std::memory_order_relaxed);
-  return _executor._async(
-    std::forward<P>(params), std::forward<F>(f), _parent->_topology, _parent
-  );
+    _parent->_join_counter.fetch_add(1, std::memory_order_relaxed);
+    return _executor._async(
+        std::forward<P>(params), std::forward<F>(f), _parent->_topology, _parent
+        );
 }
 
 // ----------------------------------------------------------------------------
@@ -439,34 +439,34 @@ auto Runtime::async(P&& params, F&& f) {
 */
 class PreemptionGuard {
 
-  public:
+public:
 
-  PreemptionGuard(Runtime& runtime) : _runtime {runtime} {
-    if(_runtime._preempted == true) {
-      TF_THROW("runtime is not preemptible");
+    PreemptionGuard(Runtime& runtime) : _runtime {runtime} {
+        if(_runtime._preempted == true) {
+            TF_THROW("runtime is not preemptible");
+        }
+        _runtime._parent->_nstate |= NSTATE::PREEMPTED;
+        _runtime._preempted = true;
+        _runtime._parent->_join_counter.fetch_add(1, std::memory_order_release);
     }
-    _runtime._parent->_nstate |= NSTATE::PREEMPTED;
-    _runtime._preempted = true;
-    _runtime._parent->_join_counter.fetch_add(1, std::memory_order_release);
-  }
 
-  ~PreemptionGuard() {
-    // If I am the last to join, then there is not need to preempt the runtime
-    if(_runtime._parent->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      _runtime._preempted = false;
-      _runtime._parent->_nstate &= ~NSTATE::PREEMPTED;
+    ~PreemptionGuard() {
+        // If I am the last to join, then there is not need to preempt the runtime
+        if(_runtime._parent->_join_counter.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            _runtime._preempted = false;
+            _runtime._parent->_nstate &= ~NSTATE::PREEMPTED;
+        }
     }
-  }
 
-  PreemptionGuard(const PreemptionGuard&) = delete;
-  PreemptionGuard(PreemptionGuard&&) = delete;
+    PreemptionGuard(const PreemptionGuard&) = delete;
+    PreemptionGuard(PreemptionGuard&&) = delete;
 
-  PreemptionGuard& operator = (const PreemptionGuard&) = delete;
-  PreemptionGuard& operator = (PreemptionGuard&&) = delete;
-  
-  private:
+    PreemptionGuard& operator = (const PreemptionGuard&) = delete;
+    PreemptionGuard& operator = (PreemptionGuard&&) = delete;
 
-  Runtime& _runtime;
+private:
+
+    Runtime& _runtime;
 };
 
 
@@ -476,71 +476,71 @@ class PreemptionGuard {
 
 // Procedure: _invoke_runtime_task
 inline bool Executor::_invoke_runtime_task(Worker& worker, Node* node) {
-  return _invoke_runtime_task_impl(
-    worker, node, std::get_if<Node::Runtime>(&node->_handle)->work
-  );
+    return _invoke_runtime_task_impl(
+        worker, node, std::get_if<Node::Runtime>(&node->_handle)->work
+        );
 }
 
 // Function: _invoke_runtime_task_impl
 inline bool Executor::_invoke_runtime_task_impl(
-  Worker& worker, Node* node, std::function<void(Runtime&)>& work
-) {
-  // first time
-  if((node->_nstate & NSTATE::PREEMPTED) == 0) {
+    Worker& worker, Node* node, WorkHandle<void(Runtime&)>& work
+    ) {
+    // first time
+    if((node->_nstate & NSTATE::PREEMPTED) == 0) {
+
+        Runtime rt(*this, worker, node);
+
+        _observer_prologue(worker, node);
+        TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+            work(rt);
+        });
+        _observer_epilogue(worker, node);
+
+        // here, we cannot check the state from node->_nstate due to data race
+        if(rt._preempted) {
+            return true;
+        }
+    }
+    // second time - previously preempted
+    else {
+        node->_nstate &= ~NSTATE::PREEMPTED;
+    }
+    return false;
+}
+
+// Function: _invoke_runtime_task_impl
+inline bool Executor::_invoke_runtime_task_impl(
+    Worker& worker, Node* node, std::function<void(Runtime&, bool)>& work
+    ) {
 
     Runtime rt(*this, worker, node);
 
-    _observer_prologue(worker, node);
-    TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-      work(rt);
-    });
-    _observer_epilogue(worker, node);
-    
-    // here, we cannot check the state from node->_nstate due to data race
-    if(rt._preempted) {
-      return true;
+    // first time
+    if((node->_nstate & NSTATE::PREEMPTED) == 0) {
+
+        _observer_prologue(worker, node);
+        TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
+            work(rt, false);
+        });
+        _observer_epilogue(worker, node);
+
+        // here, we cannot check the state from node->_nstate due to data race
+        // Ex: if preempted, another task may finish real quck and insert this parent task
+        // again into the scheduling queue. When running this parent task, it will jump to
+        // else branch below and modify tne nstate, thus incuring data race.
+        if(rt._preempted) {
+            return true;
+        }
     }
-  }
-  // second time - previously preempted
-  else {
-    node->_nstate &= ~NSTATE::PREEMPTED;
-  }
-  return false;
-}
-
-// Function: _invoke_runtime_task_impl
-inline bool Executor::_invoke_runtime_task_impl(
-  Worker& worker, Node* node, std::function<void(Runtime&, bool)>& work
-) {
-    
-  Runtime rt(*this, worker, node);
-
-  // first time
-  if((node->_nstate & NSTATE::PREEMPTED) == 0) {
-
-    _observer_prologue(worker, node);
-    TF_EXECUTOR_EXCEPTION_HANDLER(worker, node, {
-      work(rt, false);
-    });
-    _observer_epilogue(worker, node);
-    
-    // here, we cannot check the state from node->_nstate due to data race
-    // Ex: if preempted, another task may finish real quck and insert this parent task
-    // again into the scheduling queue. When running this parent task, it will jump to
-    // else branch below and modify tne nstate, thus incuring data race.
-    if(rt._preempted) {
-      return true;
+    // second time - previously preempted
+    else {
+        node->_nstate &= ~NSTATE::PREEMPTED;
     }
-  }
-  // second time - previously preempted
-  else {
-    node->_nstate &= ~NSTATE::PREEMPTED;
-  }
 
-  // clean up outstanding work
-  work(rt, true);
+    // clean up outstanding work
+    work(rt, true);
 
-  return false;
+    return false;
 }
 
 

--- a/taskflow/include/taskflow/graph/reach_matrix.hpp
+++ b/taskflow/include/taskflow/graph/reach_matrix.hpp
@@ -1,0 +1,278 @@
+#pragma once
+#include <vector>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <cassert>
+#include "../utility/dynamic_bitset.hpp"
+
+namespace tg {
+
+class ReachMatrix {
+public:
+    // 构造函数：初始化 n x n 的可达矩阵
+    explicit ReachMatrix(size_t n) {
+        if (n == 0) {
+            throw std::invalid_argument("Node count must be positive");
+        }
+        reach_.resize(n, tf::dynamic_bitset<size_t>(n));
+        for (size_t i = 0; i < n; ++i) {
+            reach_[i].set(i); // 自环可达
+        }
+    }
+
+    // 构造函数：从邻接矩阵初始化
+    explicit ReachMatrix(const std::vector<tf::dynamic_bitset<size_t>>& adj) {
+        if (adj.size() == 0) {
+            throw std::invalid_argument("Adjacency matrix cannot be empty");
+        }
+        for (const auto& row : adj) {
+            if (row.size() != adj.size()) {
+                throw std::invalid_argument("Adjacency matrix must be square");
+            }
+        }
+        reach_ = adj;
+        compute_transitive_closure();
+    }
+
+    // 构造函数：从边列表初始化
+    explicit ReachMatrix(size_t n, const std::vector<std::pair<size_t, size_t>>& edges)
+        : ReachMatrix(n) {
+        add_edges(edges);
+    }
+
+    // 添加单条边，增量更新可达矩阵
+    void add_edge(size_t from, size_t to) {
+        validate_indices(from, to);
+        if (reach_[from].test(to)) return; // 边已存在
+        reach_[from].set(to);
+        update_reachability_after_add(from, to);
+    }
+
+    // 删除单条边，重新计算受影响的可达性
+    void remove_edge(size_t from, size_t to) {
+        validate_indices(from, to);
+        if (!reach_[from].test(to)) return; // 边不存在
+        reach_[from].reset(to);
+        // 暂用全量重算，未来可优化为增量删除
+        compute_transitive_closure();
+    }
+
+    // 批量添加边
+    void add_edges(const std::vector<std::pair<size_t, size_t>>& edges) {
+        for (const auto& [from, to] : edges) {
+            validate_indices(from, to);
+            reach_[from].set(to);
+        }
+        compute_transitive_closure();
+    }
+
+    // 批量删除边
+    void remove_edges(const std::vector<std::pair<size_t, size_t>>& edges) {
+        for (const auto& [from, to] : edges) {
+            validate_indices(from, to);
+            reach_[from].reset(to);
+        }
+        // 暂用全量重算
+        compute_transitive_closure();
+    }
+
+    // 查询可达性
+    bool reachable(size_t from, size_t to) const {
+        validate_indices(from, to);
+        return reach_[from].test(to);
+    }
+
+    // 调整矩阵大小
+    void resize(size_t n) {
+        if (n == 0) {
+            throw std::invalid_argument("Node count must be positive");
+        }
+        size_t old_n = reach_.size();
+        reach_.resize(n, tf::dynamic_bitset<size_t>(n));
+        for (size_t i = 0; i < n; ++i) {
+            reach_[i].resize(n); // 调整每行大小
+            if (i < old_n) {
+                reach_[i].set(i); // 保留自环
+            } else {
+                reach_[i].set(i); // 新节点自环
+            }
+        }
+        // 重算可达性（新节点可能影响）
+        compute_transitive_closure();
+    }
+
+    // 重置矩阵
+    void reset() {
+        for (size_t i = 0; i < reach_.size(); ++i) {
+            reach_[i].reset();
+            reach_[i].set(i); // 仅设置自环
+        }
+    }
+
+    // 添加新节点
+    void push_back() {
+        size_t n = reach_.size();
+        for (auto& row : reach_) {
+            row.push_back(false);
+        }
+        reach_.emplace_back(tf::dynamic_bitset<size_t>(n + 1, false));
+        reach_.back().set(n); // 新节点自环
+    }
+
+    // 删除最后一个节点
+    void remove_back() {
+        if (reach_.size() == 0) return;
+        reach_.pop_back();
+        for (auto& row : reach_) {
+            row.pop_back();
+        }
+        // 重算可达性
+        compute_transitive_closure();
+    }
+
+    // 获取行引用
+    const tf::dynamic_bitset<size_t>& row(size_t from) const {
+        validate_indices(from, 0); // 只检查 from
+        return reach_[from];
+    }
+
+    // 获取节点数
+    size_t count() const { return reach_.size(); }
+
+    // 交换两个节点
+    void swap(size_t from, size_t to) {
+        validate_indices(from, to);
+        if (from == to) return;
+        // 交换行
+        std::swap(reach_[from], reach_[to]);
+        // 交换列
+        for (auto& row : reach_) {
+            bool temp = row.test(from);
+            row.set(from, row.test(to));
+            row.set(to, temp);
+        }
+    }
+
+    // 代理类，用于实现 [][] 访问
+    class RowProxy {
+    public:
+        RowProxy(tf::dynamic_bitset<size_t>& row) : row_(row) {}
+        
+        // 返回单个元素的可达性
+        bool operator[](size_t col) const {
+            return row_.test(col);
+        }
+        
+        // 设置单个元素的可达性
+        void set(size_t col, bool value) {
+            if (value) {
+                row_.set(col);
+            } else {
+                row_.reset(col);
+            }
+        }
+        
+        // 获取底层 bitset 的引用
+        tf::dynamic_bitset<size_t>& bitset() { return row_; }
+        const tf::dynamic_bitset<size_t>& bitset() const { return row_; }
+        
+    private:
+        tf::dynamic_bitset<size_t>& row_;
+    };
+
+    // 常量代理类
+    class ConstRowProxy {
+    public:
+        ConstRowProxy(const tf::dynamic_bitset<size_t>& row) : row_(row) {}
+        
+        // 返回单个元素的可达性
+        bool operator[](size_t col) const {
+            return row_.test(col);
+        }
+        
+        // 获取底层 bitset 的常量引用
+        const tf::dynamic_bitset<size_t>& bitset() const { return row_; }
+        
+    private:
+        const tf::dynamic_bitset<size_t>& row_;
+    };
+
+    // [][] 访问操作符 - 非常量版本
+    RowProxy operator[](size_t row) {
+        validate_indices(row, 0);
+        return RowProxy(reach_[row]);
+    }
+
+    // [][] 访问操作符 - 常量版本
+    ConstRowProxy operator[](size_t row) const {
+        validate_indices(row, 0);
+        return ConstRowProxy(reach_[row]);
+    }
+
+    // 直接访问单个元素
+    bool at(size_t row, size_t col) const {
+        validate_indices(row, col);
+        return reach_[row].test(col);
+    }
+
+    // 设置单个元素
+    void set(size_t row, size_t col, bool value) {
+        validate_indices(row, col);
+        if (value) {
+            reach_[row].set(col);
+        } else {
+            reach_[row].reset(col);
+        }
+    }
+
+private:
+    // 验证索引有效性
+    void validate_indices(size_t from, size_t to) const {
+        assert((from < reach_.size() || to < reach_.size()) && "Index out of range");
+    }
+
+    // 计算传递闭包（Warshall 算法）
+    void compute_transitive_closure() {
+        for (size_t i = 0; i < reach_.size(); ++i) {
+            reach_[i].set(i); // 自环
+        }
+        for (size_t k = 0; k < reach_.size(); ++k) {
+            for (size_t i = 0; i < reach_.size(); ++i) {
+                if (reach_[i].test(k)) {
+                    reach_[i] |= reach_[k];
+                }
+            }
+        }
+    }
+
+    // 增量更新可达性（添加边后，使用 BFS）
+    void update_reachability_after_add(size_t from, size_t to) {
+        std::vector<bool> visited(reach_.size(), false);
+        std::queue<size_t> q;
+        // 从所有能到达 from 的节点开始更新
+        for (size_t i = 0; i < reach_.size(); ++i) {
+            if (reach_[i].test(from)) {
+                q.push(i);
+                visited[i] = true;
+            }
+        }
+        // 包括 from 本身
+        if (!visited[from]) {
+            q.push(from);
+            visited[from] = true;
+        }
+
+        while (!q.empty()) {
+            size_t curr = q.front();
+            q.pop();
+            reach_[curr] |= reach_[to]; // 合并 to 的可达集
+            // 继续传播到从 curr 可达的节点（但实际只需更新直接受影响的）
+            // 注意：这里简化，实际可进一步优化避免全遍历
+        }
+    }
+
+    std::vector<tf::dynamic_bitset<size_t>> reach_; // 可达矩阵
+};
+
+} // namespace tg

--- a/taskflow/include/taskflow/utility/dynamic_bitset.hpp
+++ b/taskflow/include/taskflow/utility/dynamic_bitset.hpp
@@ -1,0 +1,166 @@
+#pragma once
+#include <vector>
+#include <cstddef>
+#include <cassert>
+
+namespace tf {
+
+template<typename BlockType = size_t>
+class dynamic_bitset {
+public:
+    using block_type = BlockType;
+    static constexpr size_t bits_per_block = sizeof(block_type) * 8;
+
+    // 构造函数
+    dynamic_bitset() = default;
+    
+    explicit dynamic_bitset(size_t n, bool value = false) {
+        resize(n, value);
+    }
+
+    // 调整大小
+    void resize(size_t n, bool value = false) {
+        size_t old_size = size();
+        size_t blocks_needed = (n + bits_per_block - 1) / bits_per_block;
+        blocks_.resize(blocks_needed, value ? ~block_type(0) : block_type(0));
+        
+        if (n < old_size) {
+            // 缩小：清除多余的位
+            clear_trailing_bits(n);
+        } else if (n > old_size) {
+            // 扩大：清除新增的位（如果 value 为 false）
+            if (!value) {
+                clear_trailing_bits(n);
+            }
+        }
+        size_ = n;
+    }
+
+    // 设置位
+    void set(size_t pos, bool value = true) {
+        assert(pos < size_);
+        size_t block_idx = pos / bits_per_block;
+        size_t bit_idx = pos % bits_per_block;
+        block_type mask = block_type(1) << bit_idx;
+        
+        if (value) {
+            blocks_[block_idx] |= mask;
+        } else {
+            blocks_[block_idx] &= ~mask;
+        }
+    }
+
+    // 重置位
+    void reset(size_t pos) {
+        set(pos, false);
+    }
+
+    // 测试位
+    bool test(size_t pos) const {
+        assert(pos < size_);
+        size_t block_idx = pos / bits_per_block;
+        size_t bit_idx = pos % bits_per_block;
+        block_type mask = block_type(1) << bit_idx;
+        return (blocks_[block_idx] & mask) != 0;
+    }
+
+    // 重置所有位
+    void reset() {
+        std::fill(blocks_.begin(), blocks_.end(), block_type(0));
+    }
+
+    // 获取大小
+    size_t size() const { return size_; }
+
+    // 计算设置位的数量
+    size_t count() const {
+        size_t result = 0;
+        for (block_type block : blocks_) {
+            result += __builtin_popcount(block);
+        }
+        return result;
+    }
+
+    // 添加位到末尾
+    void push_back(bool value) {
+        resize(size_ + 1, value);
+    }
+
+    // 从末尾移除位
+    void pop_back() {
+        if (size_ > 0) {
+            resize(size_ - 1);
+        }
+    }
+
+    // 位运算操作符
+    dynamic_bitset& operator|=(const dynamic_bitset& other) {
+        assert(size_ == other.size_);
+        for (size_t i = 0; i < blocks_.size(); ++i) {
+            blocks_[i] |= other.blocks_[i];
+        }
+        return *this;
+    }
+
+    dynamic_bitset& operator&=(const dynamic_bitset& other) {
+        assert(size_ == other.size_);
+        for (size_t i = 0; i < blocks_.size(); ++i) {
+            blocks_[i] &= other.blocks_[i];
+        }
+        return *this;
+    }
+
+    dynamic_bitset& operator^=(const dynamic_bitset& other) {
+        assert(size_ == other.size_);
+        for (size_t i = 0; i < blocks_.size(); ++i) {
+            blocks_[i] ^= other.blocks_[i];
+        }
+        return *this;
+    }
+
+    // 友元函数用于位运算
+    friend dynamic_bitset operator|(const dynamic_bitset& lhs, const dynamic_bitset& rhs) {
+        dynamic_bitset result = lhs;
+        result |= rhs;
+        return result;
+    }
+
+    friend dynamic_bitset operator&(const dynamic_bitset& lhs, const dynamic_bitset& rhs) {
+        dynamic_bitset result = lhs;
+        result &= rhs;
+        return result;
+    }
+
+    friend dynamic_bitset operator^(const dynamic_bitset& lhs, const dynamic_bitset& rhs) {
+        dynamic_bitset result = lhs;
+        result ^= rhs;
+        return result;
+    }
+
+private:
+    void clear_trailing_bits(size_t n) {
+        if (n == 0) {
+            blocks_.clear();
+            return;
+        }
+        
+        size_t last_block_idx = (n - 1) / bits_per_block;
+        size_t last_bit_idx = (n - 1) % bits_per_block;
+        
+        // 清除最后一个块中多余的位
+        if (last_block_idx < blocks_.size()) {
+            block_type mask = (block_type(1) << (last_bit_idx + 1)) - 1;
+            blocks_[last_block_idx] &= mask;
+        }
+        
+        // 清除后续块
+        for (size_t i = last_block_idx + 1; i < blocks_.size(); ++i) {
+            blocks_[i] = 0;
+        }
+    }
+
+    std::vector<block_type> blocks_;
+    size_t size_ = 0;
+};
+
+} // namespace tf

--- a/taskflow/utility/delegate.hpp
+++ b/taskflow/utility/delegate.hpp
@@ -1,0 +1,404 @@
+﻿#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace tf {
+
+/*! @brief Disambiguation tag for constructors and the like. */
+template<auto>
+struct connect_arg_t {
+    /*! @brief Default constructor. */
+    explicit connect_arg_t() = default;
+};
+
+/**
+ * @brief Constant of type connect_arg_t used to disambiguate calls.
+ * @tparam Candidate Element to connect (likely a free or member function).
+ */
+template<auto Candidate>
+inline constexpr connect_arg_t<Candidate> connect_arg{};
+
+/**
+ * @brief A class to use to push around lists of types, nothing more.
+ * @tparam Type Types provided by the type list.
+ */
+template<typename... Type>
+struct type_list {
+    /*! @brief Type list type. */
+    using type = type_list;
+    /*! @brief Compile-time number of elements in the type list. */
+    static constexpr auto size = sizeof...(Type);
+};
+
+/*! @brief Primary template isn't defined on purpose. */
+template<std::size_t, typename>
+struct type_list_element;
+
+/**
+ * @brief Provides compile-time indexed access to the types of a type list.
+ * @tparam Index Index of the type to return.
+ * @tparam First First type provided by the type list.
+ * @tparam Other Other types provided by the type list.
+ */
+template<std::size_t Index, typename First, typename... Other>
+struct type_list_element<Index, type_list<First, Other...>>
+    : type_list_element<Index - 1u, type_list<Other...>> {};
+
+/**
+ * @brief Provides compile-time indexed access to the types of a type list.
+ * @tparam First First type provided by the type list.
+ * @tparam Other Other types provided by the type list.
+ */
+template<typename First, typename... Other>
+struct type_list_element<0u, type_list<First, Other...>> {
+    /*! @brief Searched type. */
+    using type = First;
+};
+
+/**
+ * @brief Helper type.
+ * @tparam Index Index of the type to return.
+ * @tparam List Type list to search into.
+ */
+template<std::size_t Index, typename List>
+using type_list_element_t = typename type_list_element<Index, List>::type;
+
+/**
+ * @brief Transcribes the constness of a type to another type.
+ * @tparam To The type to which to transcribe the constness.
+ * @tparam From The type from which to transcribe the constness.
+ */
+template<typename To, typename From>
+struct constness_as {
+    /*! @brief The type resulting from the transcription of the constness. */
+    using type = std::remove_const_t<To>;
+};
+
+/*! @copydoc constness_as */
+template<typename To, typename From>
+struct constness_as<To, const From> {
+    /*! @brief The type resulting from the transcription of the constness. */
+    using type = const To;
+};
+
+/**
+ * @brief Alias template to facilitate the transcription of the constness.
+ * @tparam To The type to which to transcribe the constness.
+ * @tparam From The type from which to transcribe the constness.
+ */
+template<typename To, typename From>
+using constness_as_t = typename constness_as<To, From>::type;
+
+/*! @cond TURN_OFF_DOXYGEN */
+namespace internal {
+
+template<typename Ret, typename... Args>
+constexpr auto function_pointer(Ret (*)(Args...)) -> Ret (*)(Args...);
+
+template<typename Ret, typename Type, typename... Args, typename Other>
+constexpr auto function_pointer(Ret (*)(Type, Args...), Other &&) -> Ret (*)(Args...);
+
+template<typename Class, typename Ret, typename... Args, typename... Other>
+constexpr auto function_pointer(Ret (Class::*)(Args...), Other &&...) -> Ret (*)(Args...);
+
+template<typename Class, typename Ret, typename... Args, typename... Other>
+constexpr auto function_pointer(Ret (Class::*)(Args...) const, Other &&...) -> Ret (*)(Args...);
+
+template<typename Class, typename Type, typename... Other, typename = std::enable_if_t<std::is_member_object_pointer_v<Type Class::*>>>
+constexpr auto function_pointer(Type Class::*, Other &&...) -> Type (*)();
+
+template<typename... Type>
+using function_pointer_t = decltype(function_pointer(std::declval<Type>()...));
+
+template<typename... Class, typename Ret, typename... Args>
+[[nodiscard]] constexpr auto index_sequence_for(Ret (*)(Args...)) {
+    return std::index_sequence_for<Class..., Args...>{};
+}
+
+} // namespace internal
+/*! @endcond */
+
+/**
+ * @brief Basic delegate implementation.
+ *
+ * Primary template isn't defined on purpose. All the specializations give a
+ * compile-time error unless the template parameter is a function type.
+ */
+template<typename>
+class delegate;
+
+/**
+ * @brief Utility class to use to send around functions and members.
+ *
+ * Unmanaged delegate for function pointers and members. Users of this class are
+ * in charge of disconnecting instances before deleting them.
+ *
+ * A delegate can be used as a general purpose invoker without memory overhead
+ * for free functions possibly with payloads and bound or unbound members.
+ *
+ * @tparam Ret Return type of a function type.
+ * @tparam Args Types of arguments of a function type.
+ */
+template<typename Ret, typename... Args>
+class delegate<Ret(Args...)> {
+    using return_type = std::remove_const_t<Ret>;
+    using delegate_type = return_type(const void *, Args...);
+
+    template<auto Candidate, std::size_t... Index>
+    [[nodiscard]] auto wrap(std::index_sequence<Index...>) noexcept {
+        return [](const void *, Args... args) -> return_type {
+            [[maybe_unused]] const auto arguments = std::forward_as_tuple(std::forward<Args>(args)...);
+            [[maybe_unused]] constexpr auto offset = !std::is_invocable_r_v<Ret, decltype(Candidate), type_list_element_t<Index, type_list<Args...>>...> * (sizeof...(Args) - sizeof...(Index));
+            return static_cast<Ret>(std::invoke(Candidate, std::forward<type_list_element_t<Index + offset, type_list<Args...>>>(std::get<Index + offset>(arguments))...));
+        };
+    }
+
+    template<auto Candidate, typename Type, std::size_t... Index>
+    [[nodiscard]] auto wrap(Type &, std::index_sequence<Index...>) noexcept {
+        return [](const void *payload, Args... args) -> return_type {
+            Type *curr = static_cast<Type *>(const_cast<constness_as_t<void, Type> *>(payload));
+            [[maybe_unused]] const auto arguments = std::forward_as_tuple(std::forward<Args>(args)...);
+            [[maybe_unused]] constexpr auto offset = !std::is_invocable_r_v<Ret, decltype(Candidate), Type &, type_list_element_t<Index, type_list<Args...>>...> * (sizeof...(Args) - sizeof...(Index));
+            return static_cast<Ret>(std::invoke(Candidate, *curr, std::forward<type_list_element_t<Index + offset, type_list<Args...>>>(std::get<Index + offset>(arguments))...));
+        };
+    }
+
+    template<auto Candidate, typename Type, std::size_t... Index>
+    [[nodiscard]] auto wrap(Type *, std::index_sequence<Index...>) noexcept {
+        return [](const void *payload, Args... args) -> return_type {
+            Type *curr = static_cast<Type *>(const_cast<constness_as_t<void, Type> *>(payload));
+            [[maybe_unused]] const auto arguments = std::forward_as_tuple(std::forward<Args>(args)...);
+            [[maybe_unused]] constexpr auto offset = !std::is_invocable_r_v<Ret, decltype(Candidate), Type *, type_list_element_t<Index, type_list<Args...>>...> * (sizeof...(Args) - sizeof...(Index));
+            return static_cast<Ret>(std::invoke(Candidate, curr, std::forward<type_list_element_t<Index + offset, type_list<Args...>>>(std::get<Index + offset>(arguments))...));
+        };
+    }
+
+public:
+    /*! @brief Function type of the contained target. */
+    using function_type = Ret(const void *, Args...);
+    /*! @brief Function type of the delegate. */
+    using type = Ret(Args...);
+    /*! @brief Return type of the delegate. */
+    using result_type = Ret;
+
+    /*! @brief Default constructor. */
+    delegate() noexcept = default;
+    /**
+     * @brief Constructs a delegate with a given object or payload, if any.
+     * @tparam Candidate Function or member to connect to the delegate.
+     * @tparam Type Type of class or type of payload, if any.
+     * @param value_or_instance Optional valid object that fits the purpose.
+     */
+    template<auto Candidate, typename... Type>
+    delegate(connect_arg_t<Candidate>, Type &&...value_or_instance) noexcept {
+        connect<Candidate>(std::forward<Type>(value_or_instance)...);
+    }
+
+    /**
+     * @brief Constructs a delegate and connects an user defined function with
+     * optional payload.
+     * @param function Function to connect to the delegate.
+     * @param payload User defined arbitrary data.
+     */
+    delegate(function_type *function, const void *payload = nullptr) noexcept {
+        connect(function, payload);
+    }
+
+    /**
+     * @brief Connects a free function or an unbound member to a delegate.
+     * @tparam Candidate Function or member to connect to the delegate.
+     */
+    template<auto Candidate>
+    void connect() noexcept {
+        instance = nullptr;
+
+        if constexpr(std::is_invocable_r_v<Ret, decltype(Candidate), Args...>) {
+            fn = [](const void *, Args... args) -> return_type {
+                return Ret(std::invoke(Candidate, std::forward<Args>(args)...));
+            };
+        } else if constexpr(std::is_member_pointer_v<decltype(Candidate)>) {
+            fn = wrap<Candidate>(internal::index_sequence_for<type_list_element_t<0, type_list<Args...>>>(internal::function_pointer_t<decltype(Candidate)>{}));
+        } else {
+            fn = wrap<Candidate>(internal::index_sequence_for(internal::function_pointer_t<decltype(Candidate)>{}));
+        }
+    }
+
+    /**
+     * @brief Connects a free function with payload or a bound member to a
+     * delegate.
+     *
+     * The delegate isn't responsible for the connected object or the payload.
+     * Users must always guarantee that the lifetime of the instance overcomes
+     * the one of the delegate.<br/>
+     * When used to connect a free function with payload, its signature must be
+     * such that the instance is the first argument before the ones used to
+     * define the delegate itself.
+     *
+     * @tparam Candidate Function or member to connect to the delegate.
+     * @tparam Type Type of class or type of payload.
+     * @param value_or_instance A valid reference that fits the purpose.
+     */
+    template<auto Candidate, typename Type>
+    void connect(Type &value_or_instance) noexcept {
+        instance = &value_or_instance;
+
+        if constexpr(std::is_invocable_r_v<Ret, decltype(Candidate), Type &, Args...>) {
+            fn = [](const void *payload, Args... args) -> return_type {
+                Type *curr = static_cast<Type *>(const_cast<constness_as_t<void, Type> *>(payload));
+                return Ret(std::invoke(Candidate, *curr, std::forward<Args>(args)...));
+            };
+        } else {
+            fn = wrap<Candidate>(value_or_instance, internal::index_sequence_for(internal::function_pointer_t<decltype(Candidate), Type>{}));
+        }
+    }
+
+    /**
+     * @brief Connects a free function with payload or a bound member to a
+     * delegate.
+     *
+     * @sa connect(Type &)
+     *
+     * @tparam Candidate Function or member to connect to the delegate.
+     * @tparam Type Type of class or type of payload.
+     * @param value_or_instance A valid pointer that fits the purpose.
+     */
+    template<auto Candidate, typename Type>
+    void connect(Type *value_or_instance) noexcept {
+        instance = value_or_instance;
+
+        if constexpr(std::is_invocable_r_v<Ret, decltype(Candidate), Type *, Args...>) {
+            fn = [](const void *payload, Args... args) -> return_type {
+                Type *curr = static_cast<Type *>(const_cast<constness_as_t<void, Type> *>(payload));
+                return Ret(std::invoke(Candidate, curr, std::forward<Args>(args)...));
+            };
+        } else {
+            fn = wrap<Candidate>(value_or_instance, internal::index_sequence_for(internal::function_pointer_t<decltype(Candidate), Type>{}));
+        }
+    }
+
+    /**
+     * @brief Connects an user defined function with optional payload to a
+     * delegate.
+     *
+     * The delegate isn't responsible for the connected object or the payload.
+     * Users must always guarantee that the lifetime of an instance overcomes
+     * the one of the delegate.<br/>
+     * The payload is returned as the first argument to the target function in
+     * all cases.
+     *
+     * @param function Function to connect to the delegate.
+     * @param payload User defined arbitrary data.
+     */
+    void connect(function_type *function, const void *payload = nullptr) noexcept {
+        assert(function != nullptr && "Uninitialized function pointer");
+        instance = payload;
+        fn = function;
+    }
+
+    /**
+     * @brief Resets a delegate.
+     *
+     * After a reset, a delegate cannot be invoked anymore.
+     */
+    void reset() noexcept {
+        instance = nullptr;
+        fn = nullptr;
+    }
+
+    /**
+     * @brief Returns a pointer to the stored callable function target, if any.
+     * @return An opaque pointer to the stored callable function target.
+     */
+    [[nodiscard]] function_type *target() const noexcept {
+        return fn;
+    }
+
+    /**
+     * @brief Returns the instance or the payload linked to a delegate, if any.
+     * @return An opaque pointer to the underlying data.
+     */
+    [[nodiscard]] const void *data() const noexcept {
+        return instance;
+    }
+
+    /**
+     * @brief Triggers a delegate.
+     *
+     * The delegate invokes the underlying function and returns the result.
+     *
+     * @warning
+     * Attempting to trigger an invalid delegate results in undefined
+     * behavior.
+     *
+     * @param args Arguments to use to invoke the underlying function.
+     * @return The value returned by the underlying function.
+     */
+    Ret operator()(Args... args) const {
+        assert(static_cast<bool>(*this) && "Uninitialized delegate");
+        return fn(instance, std::forward<Args>(args)...);
+    }
+
+    /**
+     * @brief Checks whether a delegate actually stores a listener.
+     * @return False if the delegate is empty, true otherwise.
+     */
+    [[nodiscard]] explicit operator bool() const noexcept {
+        // no need to also test instance
+        return !(fn == nullptr);
+    }
+
+    /**
+     * @brief Compares the contents of two delegates.
+     * @param other Delegate with which to compare.
+     * @return False if the two contents differ, true otherwise.
+     */
+    [[nodiscard]] bool operator==(const delegate<Ret(Args...)> &other) const noexcept {
+        return fn == other.fn && instance == other.instance;
+    }
+
+private:
+    const void *instance{};
+    delegate_type *fn{};
+};
+
+/**
+ * @brief Compares the contents of two delegates.
+ * @tparam Ret Return type of a function type.
+ * @tparam Args Types of arguments of a function type.
+ * @param lhs A valid delegate object.
+ * @param rhs A valid delegate object.
+ * @return True if the two contents differ, false otherwise.
+ */
+template<typename Ret, typename... Args>
+[[nodiscard]] bool operator!=(const delegate<Ret(Args...)> &lhs, const delegate<Ret(Args...)> &rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+/**
+ * @brief Deduction guide.
+ * @tparam Candidate Function or member to connect to the delegate.
+ */
+template<auto Candidate>
+delegate(connect_arg_t<Candidate>) -> delegate<std::remove_pointer_t<internal::function_pointer_t<decltype(Candidate)>>>;
+
+/**
+ * @brief Deduction guide.
+ * @tparam Candidate Function or member to connect to the delegate.
+ * @tparam Type Type of class or type of payload.
+ */
+template<auto Candidate, typename Type>
+delegate(connect_arg_t<Candidate>, Type &&) -> delegate<std::remove_pointer_t<internal::function_pointer_t<decltype(Candidate), Type>>>;
+
+/**
+ * @brief Deduction guide.
+ * @tparam Ret Return type of a function type.
+ * @tparam Args Types of arguments of a function type.
+ */
+template<typename Ret, typename... Args>
+delegate(Ret (*)(const void *, Args...), const void * = nullptr) -> delegate<Ret(Args...)>;
+
+} // namespace tf


### PR DESCRIPTION
Add `[][]` access operators to `ReachMatrix` for intuitive element access, along with a new `tf::dynamic_bitset` implementation.

The `dynamic_bitset` utility was introduced to provide an efficient underlying bitset implementation, as the original `dynamic_bitset.hpp` dependency was not found. This change enhances the usability of `ReachMatrix` by allowing direct `matrix[i][j]` syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-a35b1fc1-1c9e-4090-9bef-448e948eb5d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a35b1fc1-1c9e-4090-9bef-448e948eb5d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

